### PR TITLE
Refactor CLI menu and add Kraken API wrapper

### DIFF
--- a/lib/kraken_api.py
+++ b/lib/kraken_api.py
@@ -1,0 +1,71 @@
+import base64
+import hashlib
+import hmac
+import json
+import time
+import urllib.parse
+from typing import Dict, Tuple
+
+import requests
+
+API_URL = "https://api.kraken.com"
+
+
+def load_credentials(filename: str = "config/api/kraken_key.json") -> Dict:
+    """Load API credentials from a JSON file."""
+    try:
+        with open(filename, "r") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return {}
+
+
+def get_api_pair(data: Dict, api_name: str) -> Tuple[str, str]:
+    """Return API key/secret pair for the given name."""
+    try:
+        api_key = data[api_name]["api_key"]
+        api_sec = data[api_name]["api_sec"]
+        return api_key, api_sec
+    except KeyError as exc:
+        raise ValueError(f"API credentials for '{api_name}' not found") from exc
+
+
+def _sign(uri_path: str, data: Dict, secret: str) -> str:
+    postdata = urllib.parse.urlencode(data)
+    encoded = (str(data["nonce"]) + postdata).encode()
+    message = uri_path.encode() + hashlib.sha256(encoded).digest()
+    mac = hmac.new(base64.b64decode(secret), message, hashlib.sha512)
+    return base64.b64encode(mac.digest()).decode()
+
+
+def private_request(method: str, data: Dict, api_key: str, api_sec: str) -> Dict:
+    """Perform a signed POST request to a private Kraken API method."""
+    uri_path = f"/0/private/{method}"
+    data["nonce"] = int(1000 * time.time())
+    headers = {
+        "API-Key": api_key,
+        "API-Sign": _sign(uri_path, data, api_sec),
+    }
+    resp = requests.post(API_URL + uri_path, headers=headers, data=data)
+    return resp.json()
+
+
+def public_request(method: str, params: Dict | None = None) -> Dict:
+    """Perform a GET request to a public Kraken API method."""
+    params = params or {}
+    resp = requests.get(API_URL + f"/0/public/{method}", params=params)
+    return resp.json()
+
+
+# Convenience wrappers -----------------------------------------------------
+
+def get_acc_balance(api_key: str, api_sec: str) -> Dict:
+    return private_request("Balance", {}, api_key, api_sec)
+
+
+def get_trade_balance(api_key: str, api_sec: str) -> Dict:
+    return private_request("TradeBalance", {}, api_key, api_sec)
+
+
+def ticker(pair: str = "XBTUSD") -> Dict:
+    return public_request("Ticker", {"pair": pair})

--- a/main.py
+++ b/main.py
@@ -1,42 +1,30 @@
 import config.menu.menu_settings as menu_settings
 import lib.lib as lib
 
-# api_url = "https://api.kraken.com"
+from modules.api_editor import api_list
+from modules.withdraw_adress import withdraw_adresses
+from modules.kraken_request import kraken_request
+
 api_name = "AllPerm"
-# data, filename = lib.load_json_file()
-# main()
-
-while True:
-    # Anzeigen der Optionen
-    print ('\nKRAKEN REMOTE \n')
-    option = lib.create_menu_with_options(menu_settings.main_menu_items.items())
-
-    if option == 1:
-        with open("modules/api_editor/api_list.py", mode="r", encoding="utf-8") as adresses:
-            code = adresses.read()
-        exec(code, globals())
-    elif option == 2:
-        with open("modules/withdraw_adress/withdraw_adresses.py", mode="r", encoding="utf-8") as adresses:
-            code = adresses.read()
-        exec(code, globals())
-    elif option == 3:
-        with open("modules/kraken_request/kraken_request.py", mode="r", encoding="utf-8") as request:
-            code = request.read()
-        exec(code, globals())
-    elif option == 99:
-        print('\n')
-        break
 
 
-def my_function(param1, param2):
-    """_summary_
+def main() -> None:
+    while True:
+        print("\nKRAKEN REMOTE \n")
+        option = lib.create_menu_with_options(menu_settings.main_menu_items.items())
 
-    Args:
-        param1 (_type_): _description_
-        param2 (_type_): _description_
+        if option == 1:
+            api_list.run()
+        elif option == 2:
+            withdraw_adresses.run()
+        elif option == 3:
+            kraken_request.run(api_name)
+        elif option == 99:
+            print()
+            break
+        else:
+            print("Ungültige Eingabe")
 
-    Returns:
-        _type_: _description_
-    """
-    # Implementation of my_function.
-    return param1 + param2
+
+if __name__ == "__main__":
+    main()

--- a/modules/api_editor/api_list.py
+++ b/modules/api_editor/api_list.py
@@ -1,72 +1,45 @@
-#################################
-# ╭━━━┳━━━┳━━╮╭╮╱╱╭━━┳━━━┳━━━━╮ #
-# ┃╭━╮┃╭━╮┣┫┣╯┃┃╱╱╰┫┣┫╭━╮┃╭╮╭╮┃ #
-# ┃┃╱┃┃╰━╯┃┃┃╱┃┃╱╱╱┃┃┃╰━━╋╯┃┃╰╯ #
-# ┃╰━╯┃╭━━╯┃┃╱┃┃╱╭╮┃┃╰━━╮┃╱┃┃   #
-# ┃╭━╮┃┃╱╱╭┫┣╮┃╰━╯┣┫┣┫╰━╯┃╱┃┃   #
-# ╰╯╱╰┻╯╱╱╰━━╯╰━━━┻━━┻━━━╯╱╰╯   #
-#################################  
-
-##############################  Imports  ##################################
-### stadard
 import os
 import sys
-### self created
+
 lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, lib_path)
+
 import lib.lib as lib
 import config.menu.menu_settings as menu_settings
 
-##############################  Settings  #################################
 
-### file settings ###
-### CLI
-path_to_folder = input("Folder: (default: config/api/) ") or "config/api/"
-filename = (input("Filename: (default: " + path_to_folder + "kraken_key.json)") or (path_to_folder + "kraken_key.json"))
-print(path_to_folder + '\n' + filename)
-### GUI
-# print('Select file to edit (default: config/api/kraken_key.json)')
-data, filename = lib.load_json_file(filename, path_to_folder)
+def run() -> None:
+    path_to_folder = input("Folder: (default: config/api/) ") or "config/api/"
+    filename = input(f"Filename: (default: {path_to_folder}kraken_key.json) ") or (
+        path_to_folder + "kraken_key.json")
+    print(path_to_folder + "\n" + filename)
+    data, filename = lib.load_json_file(filename, path_to_folder)
 
-#############################  Main Loop  #################################
+    while True:
+        lib.create_api_table(data)
+        print("API CONFIGURATION")
+        option = lib.create_menu_with_options(menu_settings.api_list_menu_items.items())
 
-while True:
-    # refresh data table
-    lib.create_api_table(data)    
-    # Anzeigen der Optionen
-    print ('API CONFIGURATION')
-    option = lib.create_menu_with_options(menu_settings.api_list_menu_items.items())
- 
-    # Hinzufügen eines APIKeys
-    if option == 1:
-        data = lib.add_api_keys(data, id, menu_settings.api_list_headers)
-        # Speichern der Daten in der JSON-Datei
-        lib.write_json(data, filename)
-
-    # Bearbeiten eines APIKeys
-    elif option == 2:
-        id_to_edit = input('Which ID should be edited? ')
-        for obj in data:
-            if id_to_edit in obj:
+        if option == 1:
+            new_id = str(len(data) + 1)
+            data = lib.add_api_keys(data, new_id, menu_settings.api_list_headers)
+            lib.write_json(data, filename)
+        elif option == 2:
+            id_to_edit = input("Which ID should be edited? ")
+            if id_to_edit in data:
                 lib.change_api_list(data, id_to_edit, menu_settings.api_list_headers)
-                # Speichern der Daten in der JSON-Datei
                 lib.write_json(data, filename)
-                break
+            else:
+                print("no valid id")
+        elif option == 3:
+            id_to_delete = input("Which ID should be deleted? ")
+            data = lib.delete_api_keys(data, id_to_delete)
+            lib.write_json(data, filename)
+        elif option == 99:
+            break
         else:
-            print('no valid id')
+            print("\nno valid ID")
 
-    # Löschen eines API-Keys
-    elif option == 3:
-        id_to_delete = input('Which ID should be deleted? ')
-        data = lib.delete_api_keys(data, id_to_delete)
-        # Speichern der Daten in der JSON-Datei
-        lib.write_json(data, filename)
 
-    # Zurück
-    elif option == 99:
-        break
-
-    else:
-        print('\nno valid ID')
-
-    
+if __name__ == "__main__":
+    run()

--- a/modules/kraken_request/kraken_request.py
+++ b/modules/kraken_request/kraken_request.py
@@ -1,63 +1,55 @@
-##############################  Imports  ##################################
-### stadard
 import os
 import sys
-### self created
+import json
+
 lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, lib_path)
+
 import lib.lib as lib
 import config.menu.menu_settings as menu_settings
 import lib.kraken_api as kraken_api
-import json
-##############################  Settings  #################################
-
-# SETTINGS FOR TESTING WITHOUT MAIN VARIABLES #
-
-# api settings #
-# import json
-# api_name = "AllPerm"
-
-# file settings #
-path_to_folder = "config/api/"
-filename = (path_to_folder + 'kraken_key.json')
-with open(filename) as json_data:
-   data = json.load(json_data)
 
 
-#############################  API SETTING  ################################
-# setting up api secrets #
-api_key, api_sec = kraken_api.get_api_pair(data, api_name)
+def run(api_name: str) -> None:
+    """Interactive menu for performing Kraken API requests."""
+    filename = os.path.join("config", "api", "kraken_key.json")
+    with open(filename, "r") as fh:
+        data = json.load(fh)
 
+    api_key, api_sec = kraken_api.get_api_pair(data, api_name)
 
-#############################  MAIN LOOP  #################################
-# code runs only if modul is called from main.py # 
-if __name__ == '__main__':
-    # import variables from main # 
-    from __main__ import api_name
     while True:
-        # Anzeigen der Optionen für Kraken Request Gruppen
-        print ('KRAKEN REQUESTS: \n')
+        print("KRAKEN REQUESTS:\n")
         option = lib.create_menu_with_options(menu_settings.kraken_request_menu_items.items())
 
-        # Anzeigen der Optionen für User Data # 
         if option == 1:
-            while True:
-                # Anzeigen der verschiedenen Request Typen #                      
-                    option = lib.create_menu_with_options(menu_settings.user_data_menu_items.items())
-                    if option == 99:
-                        break
-
-                    try:
-                        choice = str(option)
-                        menu_settings.user_data_requests[choice](api_key, api_sec)
-                    except (ValueError, KeyError):
-                        print("Ungültige Eingabe, bitte wählen Sie eine Option aus der Liste aus.")
-
+            _run_user_data(api_key, api_sec)
         elif option == 7:
-            data = kraken_api.ticker()
-            # print(data)
+            pair = input("Ticker pair (default: XBTUSD): ") or "XBTUSD"
+            data = kraken_api.ticker(pair)
             lib.display_data(data)
-
-
         elif option == 99:
             break
+        else:
+            print("Ungültige Eingabe")
+
+
+def _run_user_data(api_key: str, api_sec: str) -> None:
+    while True:
+        option = lib.create_menu_with_options(menu_settings.user_data_menu_items.items())
+        if option == 99:
+            break
+        func = menu_settings.user_data_requests.get(str(option))
+        if not func:
+            print("Ungültige Eingabe")
+            continue
+        try:
+            data = func(api_key, api_sec)
+            lib.display_data(data)
+        except Exception as exc:
+            print(f"Request failed: {exc}")
+
+
+if __name__ == "__main__":
+    from __main__ import api_name
+    run(api_name)

--- a/modules/withdraw_adress/withdraw_adresses.py
+++ b/modules/withdraw_adress/withdraw_adresses.py
@@ -1,56 +1,43 @@
-##############################  Imports  ##################################
-### stadard
 import os
 import sys
-### self created
+
 lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, lib_path)
+
 import lib.lib as lib
 import config.menu.menu_settings as menu_settings
 
-##############################  Settings  #################################
 
-### file settings ###
-### CLI
-path_to_folder = input("Folder: (default: config/api/) ") or "config/api/"
-filename = (input("Filename: (default: " + path_to_folder + "withdraw_db.json)") or (path_to_folder + "withdraw_db.json"))
-print(path_to_folder + '\n' + filename)
-### GUI
-print('Select file to edit (default: config/api/withdraw.db.json)')
-data, filename = lib.load_json_file(filename, path_to_folder)
+def run() -> None:
+    path_to_folder = input("Folder: (default: config/api/) ") or "config/api/"
+    filename = input(f"Filename: (default: {path_to_folder}withdraw_db.json) ") or (
+        path_to_folder + "withdraw_db.json")
+    print(path_to_folder + "\n" + filename)
+    print('Select file to edit (default: config/api/withdraw.db.json)')
+    data, filename = lib.load_json_file(filename, path_to_folder)
 
-#############################  Main Loop  #################################
+    while True:
+        print('WITHDRAW ADRESSEN')
+        lib.create_withdraw_table(data)
+        option = lib.create_menu_with_options(menu_settings.withdraw_adresses_menu_items.items())
 
-while True:
-    print ('WITHDRAW ADRESSEN')
-    ### refresh data table
-    lib.create_withdraw_table(data)
-    option = lib.create_menu_with_options(menu_settings.withdraw_adresses_menu_items.items())
+        if option == 1:
+            new_id = str(len(data) + 1)
+            lib.add_withdraw_adress(data, new_id, menu_settings.withdraw_adress_headers)
+            lib.write_json(data, filename)
+        elif option == 2:
+            id_ = input('ID des APIKeys: ')
+            lib.change_withdraw_adress(data, id_, menu_settings.withdraw_adress_headers)
+            lib.write_json(data, filename)
+        elif option == 3:
+            id_to_delete = input('ID des zu löschenden API-Keys: ')
+            lib.delete_withdraw_adress(data, id_to_delete)
+            lib.write_json(data, filename)
+        elif option == 99:
+            break
+        else:
+            print('\nno valid ID')
 
-    ### Hinzufügen einer withdraw Adresse
-    if option == 1:
-        lib.add_withdraw_adress(data, id, menu_settings.withdraw_adress_headers)
-        # Aktualisieren der Daten in der JSON-Datei
-        lib.write_json(data, filename)       
-        
-    ### Bearbeiten einer withdraw Adresse
-    elif option == 2:
-        id = input('ID des APIKeys: ')
-        lib.change_withdraw_adress(data, id, menu_settings.withdraw_adress_headers)
-        # Aktualisieren der Daten in der JSON-Datei
-        lib.write_json(data, filename)     
-        
-    ### Löschen eines Withdraw Adresse
-    elif option == 3:
-        id_to_delete = input('ID des zu löschenden API-Keys: ')
-        lib.delete_withdraw_adress(data, id_to_delete)
-        # Aktualisieren der Daten in der JSON-Datei
-        lib.write_json(data, filename) 
 
-    ### Zurück
-    elif option == 99:
-        break
-
-    else:
-        print('\nno valid ID')
-
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add basic Kraken API client for authenticated and public requests
- refactor menu modules into callable `run()` functions
- simplify main entrypoint to import modules instead of using `exec`

## Testing
- `python -m py_compile main.py modules/api_editor/api_list.py modules/withdraw_adress/withdraw_adresses.py modules/kraken_request/kraken_request.py lib/kraken_api.py`

------
https://chatgpt.com/codex/tasks/task_b_685b02affed0832a8c7672c78b394fbc