### PR TITLE
Improve error handling for empty results

### DIFF
--- a/lib/lib.py
+++ b/lib/lib.py
@@ -186,6 +186,9 @@ def display_data_balance(data):
     if not data:
         print('Error: No data provided')
         return
+    if 'error' in data and data['error']:
+        print('API Error:', '; '.join(data['error']))
+        return
     if 'result' not in data or not data['result']:
         print('Error: Data format is incorrect')
         return


### PR DESCRIPTION
## Summary
- handle `error` responses in `display_data_balance`

## Testing
- `python -m py_compile lib/lib.py`


------
https://chatgpt.com/codex/tasks/task_b_685b09f10e50832a896428f293209782