### PR TITLE
Add Telegram bot integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Copy the example files and fill in your own credentials:
 ```bash
 cp config/api/kraken_key.json.example config/api/kraken_key.json
 cp config/api/withdraw_db.json.example config/api/withdraw_db.json
+cp config/telegram/bot_settings.json.example config/telegram/bot_settings.json
 ```
 
 Edit the new `.json` files with your API keys and withdraw settings. Keep these files outside of version control.
@@ -57,6 +58,7 @@ From there you can manage API keys, withdraw addresses and perform a limited set
 
 
 For a step-by-step guide on starting and using the menu see [BOT_USAGE.md](BOT_USAGE.md).
+An overview of the project structure can be found in [docs/overview.md](docs/overview.md).
 
 ### Available Modules
 
@@ -66,6 +68,7 @@ menu interface. A few examples are:
 - **api_editor** – manage your stored API keys
 - **withdraw_adress** – edit withdraw addresses
 - **kraken_request** – make individual API requests
+- **telegram_bot** – minimal read-only Telegram bot
 - **generate-trades-history-csv** – export trade history into CSV format
 
 ### Output Folder
@@ -73,6 +76,20 @@ menu interface. A few examples are:
 Generated data such as CSV exports is stored in the `output/` directory. The
 folder only contains a `readme.md` placeholder by default and will be populated
 once modules are executed.
+
+## Telegram Bot
+
+The Telegram bot allows read-only access to your Kraken account. After
+configuring `config/telegram/bot_settings.json` with your bot token, chat ID and
+the API ID to use, you can start it from the main menu or by running
+
+```bash
+python -m modules.telegram_bot.telegram_bot
+```
+
+Available commands are `/balance` to show your account balances and `/ticker` to
+display the current price for a currency pair. More functionality can easily be
+added.
 
 ## Security Notes
 

--- a/config/menu/menu_settings.py
+++ b/config/menu/menu_settings.py
@@ -13,7 +13,7 @@ main_menu_items = {
     1: 'Bearbeiten der APIKeys',
     2: 'Bearbeiten der withdraw Adressen',
     3: 'Kraken Request',
-    # 4: 'Convert xlsx to json',
+    4: 'Telegram Bot starten',
     99: 'Zurück'
 }
 ############## kraken request menu ##############

--- a/config/telegram/bot_settings.json.example
+++ b/config/telegram/bot_settings.json.example
@@ -1,0 +1,5 @@
+{
+    "bot_token": "YOUR_TELEGRAM_BOT_TOKEN",
+    "chat_id": "YOUR_TELEGRAM_CHAT_ID",
+    "api_id": "1"
+}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,17 @@
+# Project Overview
+
+```mermaid
+flowchart TD
+    A[main.py] --> B[API key management]
+    A --> C[Withdraw addresses]
+    A --> D[Kraken requests]
+    A --> E[Telegram bot]
+    B --> F[config/api/kraken_key.json]
+    C --> G[config/api/withdraw_db.json]
+    E --> H[config/telegram/bot_settings.json]
+    D --> I[lib/kraken_api.py]
+```
+
+This diagram shows the high level components of the project and how they relate
+to the configuration files used for accessing the Kraken API and for running the
+Telegram bot.

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import lib.lib as lib
 from modules.api_editor import api_list
 from modules.withdraw_adress import withdraw_adresses
 from modules.kraken_request import kraken_request
+from modules.telegram_bot import telegram_bot
 import lib.kraken_api as kraken_api
 
 
@@ -35,6 +36,8 @@ def main() -> None:
             api_id = select_api()
             if api_id:
                 kraken_request.run(api_id)
+        elif option == 4:
+            telegram_bot.run()
         elif option == 99:
             print()
             break

--- a/modules/telegram_bot/telegram_bot.py
+++ b/modules/telegram_bot/telegram_bot.py
@@ -1,0 +1,80 @@
+import json
+import os
+import sys
+from typing import Dict
+
+from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, lib_path)
+
+import lib.kraken_api as kraken_api
+
+
+def load_bot_settings(filename: str = "config/telegram/bot_settings.json") -> Dict:
+    """Load Telegram bot settings from a JSON file."""
+    try:
+        with open(filename, "r") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return {}
+
+
+def _get_api_pair(api_id: str) -> tuple[str, str]:
+    creds = kraken_api.load_credentials()
+    try:
+        return kraken_api.get_api_pair(creds, api_id)
+    except ValueError as exc:
+        raise RuntimeError("API credentials not found") from exc
+
+
+async def cmd_start(update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(
+        "Available commands:\n/balance - show account balance\n/ticker <pair> - show ticker info"
+    )
+
+
+async def cmd_balance(update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    settings = context.bot_data.get("settings")
+    api_key, api_sec = _get_api_pair(settings.get("api_id", "1"))
+    data = kraken_api.get_acc_balance(api_key, api_sec)
+    result = data.get("result", {})
+    if not result:
+        await update.message.reply_text("Failed to fetch balance")
+        return
+    text = "Balance:\n" + "\n".join(f"{k}: {v}" for k, v in result.items())
+    await update.message.reply_text(text)
+
+
+async def cmd_ticker(update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    pair = " ".join(context.args) if context.args else "XBTUSD"
+    data = kraken_api.ticker(pair)
+    result = data.get("result")
+    if not result:
+        await update.message.reply_text("Failed to fetch ticker")
+        return
+    info = next(iter(result.values()))
+    text = f"Ticker {pair}: Last price {info.get('c',[0])[0]}"
+    await update.message.reply_text(text)
+
+
+def run() -> None:
+    settings = load_bot_settings()
+    token = settings.get("bot_token")
+    if not token:
+        print("Bot token not configured")
+        return
+
+    app = ApplicationBuilder().token(token).build()
+    app.bot_data["settings"] = settings
+
+    app.add_handler(CommandHandler("start", cmd_start))
+    app.add_handler(CommandHandler("balance", cmd_balance))
+    app.add_handler(CommandHandler("ticker", cmd_ticker))
+
+    print("Telegram bot running... press Ctrl+C to stop")
+    app.run_polling()
+
+
+if __name__ == "__main__":
+    run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ requests
 pandas
 prettytable
 PyQt5
+python-telegram-bot==20.7
+urllib3


### PR DESCRIPTION
## Summary
- add Telegram bot example configuration
- implement a minimal read-only Telegram bot
- expose Telegram bot in the menu
- document new bot and project structure
- include python-telegram-bot in requirements

## Testing
- `python -m py_compile main.py modules/telegram_bot/telegram_bot.py`
- `python -m modules.telegram_bot.telegram_bot --help` *(fails: Bot token not configured)*

------
https://chatgpt.com/codex/tasks/task_b_685b14588878832aa524b8530044a074