### PR TITLE
Introduce chatbot example

### DIFF
--- a/BOT_USAGE.md
+++ b/BOT_USAGE.md
@@ -16,6 +16,8 @@ This repository contains a simple command line tool that interacts with the Krak
    1 - Manage API keys
    2 - Manage withdraw addresses
    3 - Make a Kraken request
+   4 - Telegram bot
+   5 - Chatbots
    99 - Exit
    ```
 4. Enter the number of the option you want to use and press `Enter`.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ menu interface. A few examples are:
 - **kraken_request** – make individual API requests
 - **telegram_bot** – minimal read-only Telegram bot
 - **generate-trades-history-csv** – export trade history into CSV format
+- **chatbot** – run small strategy bots fetching data from Kraken and Yahoo Finance
 
 ### Output Folder
 
@@ -90,6 +91,18 @@ python -m modules.telegram_bot.telegram_bot
 Available commands are `/balance` to show your account balances and `/ticker` to
 display the current price for a currency pair. More functionality can easily be
 added.
+
+## Chatbots
+
+The `chatbot` module contains small strategy bots. An example `TickerBot`
+fetches price data from both Kraken and Yahoo Finance and prints the values.
+Start it from the main menu or directly via:
+
+```bash
+python -m modules.chatbot.chatbot
+```
+
+You can customise the trading pair and symbol before the bot runs.
 
 ## Security Notes
 

--- a/config/menu/menu_settings.py
+++ b/config/menu/menu_settings.py
@@ -14,6 +14,7 @@ main_menu_items = {
     2: 'Bearbeiten der withdraw Adressen',
     3: 'Kraken Request',
     4: 'Telegram Bot starten',
+    5: 'Chatbots',
     99: 'Zurück'
 }
 ############## kraken request menu ##############

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -6,10 +6,12 @@ flowchart TD
     A --> C[Withdraw addresses]
     A --> D[Kraken requests]
     A --> E[Telegram bot]
+    A --> J[Chatbots]
     B --> F[config/api/kraken_key.json]
     C --> G[config/api/withdraw_db.json]
     E --> H[config/telegram/bot_settings.json]
     D --> I[lib/kraken_api.py]
+    J --> K[modules/chatbot]
 ```
 
 This diagram shows the high level components of the project and how they relate

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from modules.api_editor import api_list
 from modules.withdraw_adress import withdraw_adresses
 from modules.kraken_request import kraken_request
 from modules.telegram_bot import telegram_bot
+from modules.chatbot import run as chatbot_run
 import lib.kraken_api as kraken_api
 
 
@@ -38,6 +39,8 @@ def main() -> None:
                 kraken_request.run(api_id)
         elif option == 4:
             telegram_bot.run()
+        elif option == 5:
+            chatbot_run()
         elif option == 99:
             print()
             break

--- a/modules/chatbot/README.md
+++ b/modules/chatbot/README.md
@@ -1,0 +1,6 @@
+# Chatbot Strategies
+
+This folder contains small strategy bots that can be executed from the main menu.
+The example `TickerBot` prints ticker data from Kraken and Yahoo Finance in short
+intervals. Use it as a starting point for implementing your own strategies.
+

--- a/modules/chatbot/__init__.py
+++ b/modules/chatbot/__init__.py
@@ -1,0 +1,6 @@
+"""Chatbot strategies module."""
+
+from .chatbot import run
+
+__all__ = ["run"]
+

--- a/modules/chatbot/base.py
+++ b/modules/chatbot/base.py
@@ -1,0 +1,49 @@
+"""Base classes and helpers for strategy chatbots."""
+
+from typing import Tuple
+
+import yfinance as yf
+
+from lib import kraken_api
+
+
+class BaseChatBot:
+    """Base chatbot providing data fetching helpers."""
+
+    def fetch_kraken_ticker(self, pair: str = "XBTUSD") -> dict:
+        """Return ticker info for a currency pair using Kraken public API."""
+        return kraken_api.ticker(pair)
+
+    def fetch_yahoo_price(self, symbol: str) -> float | None:
+        """Return the latest price for a symbol from Yahoo Finance."""
+        ticker = yf.Ticker(symbol)
+        data = ticker.history(period="1d", interval="1m")
+        if data.empty:
+            return None
+        return float(data["Close"].iloc[-1])
+
+
+class TickerBot(BaseChatBot):
+    """Simple bot that prints prices from Kraken and Yahoo Finance."""
+
+    def __init__(self, pair: str = "XBTUSD", symbol: str = "AAPL", delay: int = 5):
+        self.pair = pair
+        self.symbol = symbol
+        self.delay = delay
+
+    def run(self) -> None:
+        import time
+
+        print(
+            f"Starting TickerBot for Kraken pair {self.pair} and Yahoo symbol {self.symbol}"
+        )
+        for _ in range(3):
+            kdata = self.fetch_kraken_ticker(self.pair)
+            last = None
+            if kdata.get("result"):
+                info = next(iter(kdata["result"].values()))
+                last = info.get("c", [None])[0]
+            yprice = self.fetch_yahoo_price(self.symbol)
+            print(f"Kraken last: {last}  Yahoo price: {yprice}")
+            time.sleep(self.delay)
+

--- a/modules/chatbot/chatbot.py
+++ b/modules/chatbot/chatbot.py
@@ -1,0 +1,18 @@
+"""Runner for example chatbots."""
+
+from .base import TickerBot
+
+
+def run() -> None:
+    """Simple interface for running demo chatbots."""
+    print("CHATBOT DEMO")
+    print("1. Run ticker bot")
+    print("99. Back")
+    choice = input("Option: ") or "99"
+    if choice == "1":
+        pair = input("Kraken pair (default: XBTUSD): ") or "XBTUSD"
+        symbol = input("Yahoo symbol (default: AAPL): ") or "AAPL"
+        bot = TickerBot(pair=pair, symbol=symbol)
+        bot.run()
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ prettytable
 PyQt5
 python-telegram-bot==20.7
 urllib3
+yfinance


### PR DESCRIPTION
## Summary
- add placeholder chatbot package with a small `TickerBot`
- register chatbot runner in menu and main menu
- document new option in BOT_USAGE and README
- expand project overview diagram
- require `yfinance` for market data access

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685b174ca9a4832a8104c7e64919c66f