### PR TITLE
Add ElliottWaveBot strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,20 @@ added.
 
 The `chatbot` module contains small strategy bots. An example `TickerBot`
 fetches price data from both Kraken and Yahoo Finance and prints the values.
+Another demo called `ElliottWaveBot` performs a very rough Elliott wave
+analysis on historical prices and simulates trades based on configurable
+criteria.
 Start it from the main menu or directly via:
 
 ```bash
 python -m modules.chatbot.chatbot
 ```
 
-You can customise the trading pair and symbol before the bot runs.
+You can customise the trading pair and symbol before the bot runs. When
+starting the Elliott wave bot you may pass a settings file path to tweak
+parameters such as analysis period, price interval and profit margin.
+See [docs/elliott_wave_bot.md](docs/elliott_wave_bot.md) for a detailed
+description of the available options.
 
 ## Security Notes
 

--- a/config/chatbot/elliott_wave_settings.json.example
+++ b/config/chatbot/elliott_wave_settings.json.example
@@ -1,0 +1,8 @@
+{
+    "symbol": "BTC-USD",
+    "period": "1y",
+    "interval": "1d",
+    "profit_pct": 2.0,
+    "start_balance": 1000,
+    "wave_threshold_pct": 2.5
+}

--- a/docs/elliott_wave_bot.md
+++ b/docs/elliott_wave_bot.md
@@ -1,0 +1,56 @@
+# ElliottWaveBot
+
+`ElliottWaveBot` is an experimental strategy that tries to detect basic Elliott wave
+patterns in historical price data. It loads settings from a JSON file so you can
+quickly adjust parameters without modifying the code. The bot only prints buy and
+sell signals and performs a simple simulation to show the resulting balance if
+you had followed those trades.
+
+## Configuration
+
+Copy `config/chatbot/elliott_wave_settings.json.example` to
+`config/chatbot/elliott_wave_settings.json` and edit the values:
+
+```json
+{
+    "symbol": "BTC-USD",
+    "period": "1y",
+    "interval": "1d",
+    "profit_pct": 2.0,
+    "start_balance": 1000,
+    "wave_threshold_pct": 2.5
+}
+```
+
+### Options
+
+- **symbol** – Ticker symbol used with Yahoo Finance. Determines which asset
+  prices are analysed.
+- **period** – How far back the historical data should go (e.g. `1y` for one
+  year or `6mo` for six months).
+- **interval** – Resolution of the price data (`1d`, `1h`, etc.). Shorter
+  intervals increase the number of potential waves and therefore trades.
+- **profit_pct** – Minimum percentage difference between a low and the
+  subsequent high before a trade is triggered. Larger values reduce the number of
+  trades but target higher profits.
+- **start_balance** – Virtual starting balance used for the simulation.
+- **wave_threshold_pct** – Percentage price move required to mark a new swing in
+  the simplified wave detection. Lower values create more waves and therefore
+  more trades.
+
+Changing these values influences how many signals the bot will generate. For
+example, reducing `wave_threshold_pct` and `interval` leads to frequent trades
+on small moves while increasing them will result in fewer but potentially larger
+trades.
+
+## Running the bot
+
+Start the chatbot menu and choose the Elliott wave bot:
+
+```bash
+python -m modules.chatbot.chatbot
+```
+
+When prompted for a settings file you can either accept the default path or
+specify your own configuration. The bot will fetch historical prices, generate
+signals and display the final simulated balance along with the executed trades.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -12,6 +12,7 @@ flowchart TD
     E --> H[config/telegram/bot_settings.json]
     D --> I[lib/kraken_api.py]
     J --> K[modules/chatbot]
+    K --> L[config/chatbot/elliott_wave_settings.json]
 ```
 
 This diagram shows the high level components of the project and how they relate

--- a/modules/chatbot/chatbot.py
+++ b/modules/chatbot/chatbot.py
@@ -1,18 +1,30 @@
 """Runner for example chatbots."""
 
 from .base import TickerBot
+from .elliott_wave_bot import ElliottWaveBot, Settings
 
 
 def run() -> None:
     """Simple interface for running demo chatbots."""
     print("CHATBOT DEMO")
     print("1. Run ticker bot")
+    print("2. Run Elliott wave bot")
     print("99. Back")
     choice = input("Option: ") or "99"
     if choice == "1":
         pair = input("Kraken pair (default: XBTUSD): ") or "XBTUSD"
         symbol = input("Yahoo symbol (default: AAPL): ") or "AAPL"
         bot = TickerBot(pair=pair, symbol=symbol)
+        bot.run()
+    elif choice == "2":
+        filename = (
+            input(
+                "Settings file (default: config/chatbot/elliott_wave_settings.json): "
+            )
+            or "config/chatbot/elliott_wave_settings.json"
+        )
+        settings = Settings.load(filename)
+        bot = ElliottWaveBot(settings)
         bot.run()
 
 

--- a/modules/chatbot/elliott_wave_bot.py
+++ b/modules/chatbot/elliott_wave_bot.py
@@ -1,0 +1,129 @@
+"""Elliott Wave strategy bot generating trade recommendations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import json
+import os
+
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class Trade:
+    action: str  # "buy" or "sell"
+    price: float
+    time: pd.Timestamp
+
+
+@dataclass
+class Settings:
+    symbol: str = "BTC-USD"
+    period: str = "1y"
+    interval: str = "1d"
+    profit_pct: float = 2.0
+    start_balance: float = 1000.0
+    wave_threshold_pct: float = 2.5
+
+    @staticmethod
+    def load(filename: str) -> "Settings":
+        with open(filename, "r") as fh:
+            data = json.load(fh)
+        return Settings(**data)
+
+
+class ElliottWaveBot:
+    """Simple Elliott Wave based strategy."""
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self.data: pd.DataFrame | None = None
+        self.trades: List[Trade] = []
+
+    def fetch_data(self) -> pd.DataFrame:
+        ticker = yf.Ticker(self.settings.symbol)
+        df = ticker.history(period=self.settings.period, interval=self.settings.interval)
+        df = df.dropna()
+        self.data = df
+        return df
+
+    # Basic zigzag detection to approximate waves
+    def _detect_waves(self) -> List[Tuple[pd.Timestamp, float]]:
+        if self.data is None or self.data.empty:
+            return []
+        df = self.data
+        threshold = self.settings.wave_threshold_pct / 100
+        highs = df["High"]
+        lows = df["Low"]
+        points: List[Tuple[pd.Timestamp, float]] = []
+        last_extreme = df.index[0]
+        last_price = df["Close"].iloc[0]
+        last_is_high = None
+        for time, row in df.iterrows():
+            price = row["Close"]
+            change = (price - last_price) / last_price
+            if last_is_high is None:
+                if abs(change) >= threshold:
+                    last_is_high = price > last_price
+                    last_extreme = time
+                    last_price = price
+                    points.append((time, price))
+            else:
+                if last_is_high and price < last_price * (1 - threshold):
+                    last_is_high = False
+                    last_extreme = time
+                    last_price = price
+                    points.append((time, price))
+                elif not last_is_high and price > last_price * (1 + threshold):
+                    last_is_high = True
+                    last_extreme = time
+                    last_price = price
+                    points.append((time, price))
+        return points
+
+    def _generate_signals(self) -> None:
+        waves = self._detect_waves()
+        if len(waves) < 2:
+            return
+        # Buy after trough, sell after next peak with profit_pct requirement
+        for i in range(len(waves) - 1):
+            t0, p0 = waves[i]
+            t1, p1 = waves[i + 1]
+            if p1 > p0 * (1 + self.settings.profit_pct / 100):
+                self.trades.append(Trade("buy", p0, t0))
+                self.trades.append(Trade("sell", p1, t1))
+
+    def simulate(self) -> float:
+        if self.data is None:
+            self.fetch_data()
+        self._generate_signals()
+        balance = self.settings.start_balance
+        position = 0.0
+        for trade in self.trades:
+            if trade.action == "buy" and balance > 0:
+                position = balance / trade.price
+                balance = 0.0
+            elif trade.action == "sell" and position > 0:
+                balance = position * trade.price
+                position = 0.0
+        # If we end with a position, liquidate at last close
+        if position > 0 and self.data is not None:
+            balance = position * float(self.data["Close"].iloc[-1])
+        return balance
+
+    def run(self) -> None:
+        self.fetch_data()
+        final_balance = self.simulate()
+        print(f"ElliottWaveBot finished. Trades executed: {len(self.trades)}")
+        print(f"Final balance starting from {self.settings.start_balance}: {final_balance:.2f}")
+        for trade in self.trades:
+            print(f"{trade.time.date()} - {trade.action.upper()} at {trade.price:.2f}")
+
+
+if __name__ == "__main__":
+    settings = Settings.load("config/chatbot/elliott_wave_settings.json")
+    bot = ElliottWaveBot(settings)
+    bot.run()


### PR DESCRIPTION
## Summary
- implement ElliottWaveBot for a simple elliott wave based simulation
- extend chatbot menu to run the new strategy
- add configuration example for ElliottWaveBot
- document usage and settings
- mention bot docs in README and update overview diagram

## Testing
- `python -m py_compile modules/chatbot/chatbot.py modules/chatbot/elliott_wave_bot.py`

------
https://chatgpt.com/codex/tasks/task_b_685b221a39b4832ab9c7b991e568ee26