### PR TITLE
Add live trading bot and API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ From there you can manage API keys, withdraw addresses and perform a limited set
 
 For a step-by-step guide on starting and using the menu see [BOT_USAGE.md](BOT_USAGE.md).
 An overview of the project structure can be found in [docs/overview.md](docs/overview.md).
+The available helper functions for the Kraken API are summarised in
+[docs/kraken_api_reference.md](docs/kraken_api_reference.md).
 
 ### Available Modules
 

--- a/config/chatbot/live_trader_settings.json.example
+++ b/config/chatbot/live_trader_settings.json.example
@@ -1,0 +1,9 @@
+{
+    "symbol": "BTC-USD",
+    "lookback_days": 30,
+    "interval": "1h",
+    "trade_amount": 1000,
+    "profit_target_pct": 1.5,
+    "check_interval": 30,
+    "debug": true
+}

--- a/docs/kraken_api_reference.md
+++ b/docs/kraken_api_reference.md
@@ -1,0 +1,23 @@
+# Kraken API Overview
+
+Die Datei `lib/kraken_api.py` enthält kleine Helferfunktionen für die wichtigsten Endpunkte der Kraken REST‑API. Im Menü "Kraken Request" können sie über die ID des gewünschten API‑Schlüssels aufgerufen werden. Folgende Funktionen stehen zur Verfügung:
+
+| Funktion                | Beschreibung                                           |
+|-------------------------|--------------------------------------------------------|
+| `get_acc_balance`       | Kontostand aller Assets abrufen. Benötigt privaten API‑Key. |
+| `get_trade_balance`     | Übersicht über das Trading-Konto.                      |
+| `get_open_orders`       | Alle offenen Order anzeigen.                            |
+| `get_closed_orders`     | Abgeschlossene Order anzeigen.                          |
+| `query_orders_info`     | Informationen zu bestimmten Order-IDs anfordern.       |
+| `get_trades_history`    | Historie aller Trades zurückliefern.                   |
+| `query_trades_info`     | Details zu einzelnen Trade-IDs.                        |
+| `get_open_positions`    | Offene Positionen anzeigen.                            |
+| `get_ledgers_info`      | Überblick über sämtliche Kontobewegungen.             |
+| `query_ledgers_info`    | Details zu bestimmten Ledger-IDs.                      |
+| `get_trade_volume`      | Handelsvolumen für bestimmte Währungspaare.           |
+| `request_export_report` | Erstellung eines Export-Reports anstoßen.             |
+| `ticker`                | Öffentlicher Aufruf – aktuelle Marktdaten zu einem Paar. |
+
+Die privaten Funktionen benötigen einen gültigen API‑Key und das zugehörige Secret, wie in `config/api/kraken_key.json` hinterlegt. Die Namen der Parameter entsprechen direkt den Anforderungen der Kraken‑API, so dass du sie in beliebiger Kombination verwenden kannst.
+
+Weitere Details zu den Parametern findest du in der offiziellen [Kraken API Dokumentation](https://docs.kraken.com/rest/).

--- a/docs/live_trader_bot.md
+++ b/docs/live_trader_bot.md
@@ -1,0 +1,45 @@
+# LiveTraderBot
+
+`LiveTraderBot` ist ein einfacher Bot, der kontinuierlich Kursdaten aus Yahoo Finance auswertet und anhand einer Moving-Average-Strategie Kauf- und Verkaufszeitpunkte simuliert. Im Gegensatz zum `ElliottWaveBot` stoppt dieser Bot nicht nach einer Simulation, sondern läuft dauerhaft weiter und aktualisiert seine Berechnungen regelmäßig.
+
+## Konfiguration
+
+Kopiere `config/chatbot/live_trader_settings.json.example` nach `config/chatbot/live_trader_settings.json` und passe die Werte an:
+
+```json
+{
+    "symbol": "BTC-USD",
+    "lookback_days": 30,
+    "interval": "1h",
+    "trade_amount": 1000,
+    "profit_target_pct": 1.5,
+    "check_interval": 30,
+    "debug": true
+}
+```
+
+### Felder
+
+- **symbol** – Ticker‑Symbol für Yahoo Finance (z. B. `BTC-USD`).
+- **lookback_days** – Wie viele Tage an Historie beim Abruf verwendet werden.
+- **interval** – Zeitintervall der historischen Daten (`1h`, `1d` …).
+- **trade_amount** – Virtuelles Startkapital, das beim ersten Kaufsignal eingesetzt wird.
+- **profit_target_pct** – Prozentualer Aufschlag auf den Kaufkurs, bei dem ein Verkauf erfolgen soll.
+- **check_interval** – Wie viele Sekunden zwischen zwei Aktualisierungen liegen.
+- **debug** – Wenn `true`, werden die berechneten Werte jedes Mal auf der Konsole ausgegeben.
+
+Während der Laufzeit speichert der Bot seinen Zustand in `output/live_trader_state.json`. Dort findest du den aktuellen Kurs, gleitende Durchschnitte, offene Positionen und die letzte Aktion.
+
+## Starten des Bots
+
+Der Bot kann über das Chatbot-Menü gestartet werden:
+
+```bash
+python -m modules.chatbot.chatbot
+```
+
+Option **3** wählt den LiveTraderBot. Anschließend kann ein abweichender Pfad zur Einstellungsdatei angegeben werden oder du bestätigst den Standardpfad.
+
+## Funktionsweise
+
+Alle `check_interval` Sekunden ruft der Bot die jüngsten Kursdaten für das gewünschte Symbol ab. Liegt der kurzfristige gleitende Durchschnitt über dem langfristigen Durchschnitt und der aktuelle Kurs nicht wesentlich darüber, wird mit dem verfügbaren Kapital gekauft. Nach einem Kauf wird ein Verkaufsziel berechnet (`profit_target_pct`). Erreicht der Kurs dieses Ziel, wird verkauft und die Position geschlossen. Jede Berechnung wird in die Zustandsdatei geschrieben, sodass du jederzeit sehen kannst, welche Daten analysiert wurden und welche Entscheidung getroffen wurde.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,8 +13,14 @@ flowchart TD
     D --> I[lib/kraken_api.py]
     J --> K[modules/chatbot]
     K --> L[config/chatbot/elliott_wave_settings.json]
+    K --> M[config/chatbot/live_trader_settings.json]
 ```
 
 This diagram shows the high level components of the project and how they relate
 to the configuration files used for accessing the Kraken API and for running the
 Telegram bot.
+
+Additional strategy bots use JSON settings located in `config/chatbot/`. Along
+with the Elliott wave example you can configure a continuously running
+`LiveTraderBot` via `live_trader_settings.json` described in
+`docs/live_trader_bot.md`.

--- a/modules/chatbot/chatbot.py
+++ b/modules/chatbot/chatbot.py
@@ -2,6 +2,7 @@
 
 from .base import TickerBot
 from .elliott_wave_bot import ElliottWaveBot, Settings
+from .live_trader_bot import LiveTraderBot, LiveSettings
 
 
 def run() -> None:
@@ -9,6 +10,7 @@ def run() -> None:
     print("CHATBOT DEMO")
     print("1. Run ticker bot")
     print("2. Run Elliott wave bot")
+    print("3. Run live trader bot")
     print("99. Back")
     choice = input("Option: ") or "99"
     if choice == "1":
@@ -25,6 +27,16 @@ def run() -> None:
         )
         settings = Settings.load(filename)
         bot = ElliottWaveBot(settings)
+        bot.run()
+    elif choice == "3":
+        filename = (
+            input(
+                "Settings file (default: config/chatbot/live_trader_settings.json): "
+            )
+            or "config/chatbot/live_trader_settings.json"
+        )
+        settings = LiveSettings.load(filename)
+        bot = LiveTraderBot(settings)
         bot.run()
 
 

--- a/modules/chatbot/live_trader_bot.py
+++ b/modules/chatbot/live_trader_bot.py
@@ -1,0 +1,105 @@
+"""Live trading simulation bot that runs continuously."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Dict
+
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class LiveSettings:
+    """Configuration for :class:`LiveTraderBot`."""
+
+    symbol: str = "BTC-USD"
+    lookback_days: int = 30
+    interval: str = "1h"
+    trade_amount: float = 1000.0
+    profit_target_pct: float = 1.5
+    check_interval: int = 30
+    debug: bool = True
+
+    @staticmethod
+    def load(filename: str) -> "LiveSettings":
+        with open(filename, "r") as fh:
+            data = json.load(fh)
+        return LiveSettings(**data)
+
+
+class LiveTraderBot:
+    """Very simple strategy that buys once an upward trend is detected."""
+
+    def __init__(self, settings: LiveSettings) -> None:
+        self.settings = settings
+        self.position = 0.0
+        self.cash = settings.trade_amount
+        self.last_buy_price: float | None = None
+        self.target_sell_price: float | None = None
+        self.state_file = "output/live_trader_state.json"
+
+    def _fetch_data(self) -> pd.DataFrame:
+        ticker = yf.Ticker(self.settings.symbol)
+        period = f"{self.settings.lookback_days}d"
+        df = ticker.history(period=period, interval=self.settings.interval)
+        return df.dropna()
+
+    def _write_state(self, info: Dict) -> None:
+        try:
+            with open(self.state_file, "w") as fh:
+                json.dump(info, fh, indent=2)
+        except OSError:
+            pass
+
+    def _log(self, info: Dict) -> None:
+        if self.settings.debug:
+            print(json.dumps(info, indent=2))
+
+    def run(self) -> None:
+        print(
+            f"Starting LiveTraderBot for {self.settings.symbol} with trade amount {self.settings.trade_amount}"
+        )
+        while True:
+            df = self._fetch_data()
+            price = float(df["Close"].iloc[-1])
+            short_ma = float(df["Close"].rolling(window=7).mean().iloc[-1])
+            long_ma = float(df["Close"].rolling(window=25).mean().iloc[-1])
+
+            action = None
+            if self.position == 0 and short_ma > long_ma and price <= short_ma:
+                self.position = self.cash / price
+                self.cash = 0.0
+                self.last_buy_price = price
+                self.target_sell_price = price * (1 + self.settings.profit_target_pct / 100)
+                action = f"BUY {self.position:.6f} at {price:.2f}"
+            elif self.position > 0 and price >= (self.target_sell_price or 0):
+                self.cash = self.position * price
+                self.position = 0.0
+                action = f"SELL at {price:.2f}"
+                self.target_sell_price = None
+
+            info = {
+                "timestamp": pd.Timestamp.utcnow().isoformat(),
+                "price": price,
+                "short_ma": short_ma,
+                "long_ma": long_ma,
+                "position": self.position,
+                "cash": self.cash,
+                "last_buy_price": self.last_buy_price,
+                "target_sell_price": self.target_sell_price,
+                "next_buy_price": short_ma if self.position == 0 else None,
+                "action": action,
+            }
+
+            self._write_state(info)
+            self._log(info)
+            time.sleep(self.settings.check_interval)
+
+
+if __name__ == "__main__":
+    settings = LiveSettings.load("config/chatbot/live_trader_settings.json")
+    bot = LiveTraderBot(settings)
+    bot.run()


### PR DESCRIPTION
## Summary
- document Kraken API helper functions
- add continuously running `LiveTraderBot`
- provide example settings for new bot
- hook bot into chatbot menu
- document new bot and update overview

## Testing
- `python -m py_compile modules/chatbot/live_trader_bot.py`
- `python -m py_compile modules/chatbot/chatbot.py`

------
https://chatgpt.com/codex/tasks/task_b_685b29d55ef8832aa4e66cecbe322b79