### PR TITLE
Enable Telegram notifications for LiveTraderBot

### DIFF
--- a/config/chatbot/live_trader_settings.json.example
+++ b/config/chatbot/live_trader_settings.json.example
@@ -5,5 +5,7 @@
     "trade_amount": 1000,
     "profit_target_pct": 1.5,
     "check_interval": 30,
-    "debug": true
+    "debug": true,
+    "telegram_enabled": false,
+    "telegram_settings_file": "config/telegram/bot_settings.json"
 }

--- a/docs/live_trader_bot.md
+++ b/docs/live_trader_bot.md
@@ -1,6 +1,6 @@
 # LiveTraderBot
 
-`LiveTraderBot` ist ein einfacher Bot, der kontinuierlich Kursdaten aus Yahoo Finance auswertet und anhand einer Moving-Average-Strategie Kauf- und Verkaufszeitpunkte simuliert. Im Gegensatz zum `ElliottWaveBot` stoppt dieser Bot nicht nach einer Simulation, sondern läuft dauerhaft weiter und aktualisiert seine Berechnungen regelmäßig.
+`LiveTraderBot` ist ein einfacher Bot, der kontinuierlich Kursdaten aus Yahoo Finance auswertet und anhand einer Moving-Average-Strategie Kauf- und Verkaufszeitpunkte simuliert. Er verschickt dabei lediglich Handlungsempfehlungen und führt keine echten Trades aus. Im Gegensatz zum `ElliottWaveBot` stoppt dieser Bot nicht nach einer Simulation, sondern läuft dauerhaft weiter und aktualisiert seine Berechnungen regelmäßig. Aktivierst du Telegram, werden die Empfehlungen an dein Chatfenster gesendet.
 
 ## Konfiguration
 
@@ -14,7 +14,9 @@ Kopiere `config/chatbot/live_trader_settings.json.example` nach `config/chatbot/
     "trade_amount": 1000,
     "profit_target_pct": 1.5,
     "check_interval": 30,
-    "debug": true
+    "debug": true,
+    "telegram_enabled": false,
+    "telegram_settings_file": "config/telegram/bot_settings.json"
 }
 ```
 
@@ -27,6 +29,8 @@ Kopiere `config/chatbot/live_trader_settings.json.example` nach `config/chatbot/
 - **profit_target_pct** – Prozentualer Aufschlag auf den Kaufkurs, bei dem ein Verkauf erfolgen soll.
 - **check_interval** – Wie viele Sekunden zwischen zwei Aktualisierungen liegen.
 - **debug** – Wenn `true`, werden die berechneten Werte jedes Mal auf der Konsole ausgegeben.
+- **telegram_enabled** – Wenn `true`, werden Empfehlungen per Telegram verschickt.
+- **telegram_settings_file** – Pfad zur Datei mit Bot-Token und Chat-ID.
 
 Während der Laufzeit speichert der Bot seinen Zustand in `output/live_trader_state.json`. Dort findest du den aktuellen Kurs, gleitende Durchschnitte, offene Positionen und die letzte Aktion.
 
@@ -42,4 +46,4 @@ Option **3** wählt den LiveTraderBot. Anschließend kann ein abweichender Pfad 
 
 ## Funktionsweise
 
-Alle `check_interval` Sekunden ruft der Bot die jüngsten Kursdaten für das gewünschte Symbol ab. Liegt der kurzfristige gleitende Durchschnitt über dem langfristigen Durchschnitt und der aktuelle Kurs nicht wesentlich darüber, wird mit dem verfügbaren Kapital gekauft. Nach einem Kauf wird ein Verkaufsziel berechnet (`profit_target_pct`). Erreicht der Kurs dieses Ziel, wird verkauft und die Position geschlossen. Jede Berechnung wird in die Zustandsdatei geschrieben, sodass du jederzeit sehen kannst, welche Daten analysiert wurden und welche Entscheidung getroffen wurde.
+Alle `check_interval` Sekunden ruft der Bot die jüngsten Kursdaten für das gewünschte Symbol ab. Liegt der kurzfristige gleitende Durchschnitt über dem langfristigen Durchschnitt und der aktuelle Kurs nicht wesentlich darüber, empfiehlt der Bot einen Kauf. Nach einem virtuellen Kauf wird ein Verkaufsziel berechnet (`profit_target_pct`). Erreicht der Kurs dieses Ziel, wird eine Verkaufsempfehlung ausgesprochen und die Position geschlossen. Jede Berechnung wird in die Zustandsdatei geschrieben, sodass du jederzeit sehen kannst, welche Daten analysiert wurden und welche Entscheidung getroffen wurde.

--- a/modules/chatbot/live_trader_bot.py
+++ b/modules/chatbot/live_trader_bot.py
@@ -22,12 +22,15 @@ class LiveSettings:
     profit_target_pct: float = 1.5
     check_interval: int = 30
     debug: bool = True
+    telegram_enabled: bool = False
+    telegram_settings_file: str = "config/telegram/bot_settings.json"
 
     @staticmethod
     def load(filename: str) -> "LiveSettings":
         with open(filename, "r") as fh:
             data = json.load(fh)
-        return LiveSettings(**data)
+        valid = {k: v for k, v in data.items() if k in LiveSettings.__annotations__}
+        return LiveSettings(**valid)
 
 
 class LiveTraderBot:
@@ -40,6 +43,17 @@ class LiveTraderBot:
         self.last_buy_price: float | None = None
         self.target_sell_price: float | None = None
         self.state_file = "output/live_trader_state.json"
+        self.telegram_token: str | None = None
+        self.telegram_chat_id: str | None = None
+        if self.settings.telegram_enabled:
+            try:
+                with open(self.settings.telegram_settings_file, "r") as fh:
+                    data = json.load(fh)
+                self.telegram_token = data.get("bot_token")
+                self.telegram_chat_id = data.get("chat_id")
+            except FileNotFoundError:
+                print("Telegram settings file not found")
+                self.settings.telegram_enabled = False
 
     def _fetch_data(self) -> pd.DataFrame:
         ticker = yf.Ticker(self.settings.symbol)
@@ -57,6 +71,34 @@ class LiveTraderBot:
     def _log(self, info: Dict) -> None:
         if self.settings.debug:
             print(json.dumps(info, indent=2))
+
+    def _notify(self, info: Dict) -> None:
+        if not self.settings.telegram_enabled:
+            return
+        if not (self.telegram_token and self.telegram_chat_id):
+            return
+        import requests
+
+        text_lines = [
+            f"{info.get('timestamp')}",
+            f"Action: {info.get('action') or 'HOLD'}",
+            f"Price: {info.get('price'):.2f}",
+            f"Short MA: {info.get('short_ma'):.2f}",
+            f"Long MA: {info.get('long_ma'):.2f}",
+            f"Position: {info.get('position'):.6f}",
+            f"Cash: {info.get('cash'):.2f}",
+            f"Target sell: {info.get('target_sell_price')}",
+            f"Next buy: {info.get('next_buy_price')}",
+        ]
+        text = "\n".join(text_lines)
+        try:
+            requests.post(
+                f"https://api.telegram.org/bot{self.telegram_token}/sendMessage",
+                data={"chat_id": self.telegram_chat_id, "text": text},
+                timeout=10,
+            )
+        except requests.RequestException:
+            pass
 
     def run(self) -> None:
         print(
@@ -96,6 +138,7 @@ class LiveTraderBot:
 
             self._write_state(info)
             self._log(info)
+            self._notify(info)
             time.sleep(self.settings.check_interval)
 
 


### PR DESCRIPTION
## Summary
- add optional Telegram integration in `LiveTraderBot`
- document new options `telegram_enabled` and `telegram_settings_file`
- update example configuration with Telegram fields

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685b2c027314832aa5a47689f82da875