### PR TITLE
Improve docs about time input

### DIFF
--- a/docs/elliott_wave_bot.md
+++ b/docs/elliott_wave_bot.md
@@ -38,6 +38,19 @@ Copy `config/chatbot/elliott_wave_settings.json.example` to
   the simplified wave detection. Lower values create more waves and therefore
   more trades.
 
+### Valid periods and intervals
+
+Historical data is requested via Yahoo Finance, which accepts specific strings
+for time ranges and resolutions:
+
+- **Periods**: `1d`, `5d`, `1mo`, `3mo`, `6mo`, `1y`, `2y`, `5y`, `10y`, `ytd`,
+  `max`
+- **Intervals**: `1m`, `2m`, `5m`, `15m`, `30m`, `60m`, `90m`, `1h`, `1d`, `5d`,
+  `1wk`, `1mo`, `3mo`
+
+Intraday intervals (`1m`–`1h`) are limited to roughly the last 60 days of
+history.
+
 Changing these values influences how many signals the bot will generate. For
 example, reducing `wave_threshold_pct` and `interval` leads to frequent trades
 on small moves while increasing them will result in fewer but potentially larger

--- a/docs/live_trader_bot.md
+++ b/docs/live_trader_bot.md
@@ -32,6 +32,22 @@ Kopiere `config/chatbot/live_trader_settings.json.example` nach `config/chatbot/
 - **telegram_enabled** – Wenn `true`, werden Empfehlungen per Telegram verschickt.
 - **telegram_settings_file** – Pfad zur Datei mit Bot-Token und Chat-ID.
 
+### Gültige Zeitangaben
+
+Die Daten stammen von Yahoo Finance. Für `interval` kannst du eine der
+folgenden Auflösungen angeben:
+
+- `1m`, `2m`, `5m`, `15m`, `30m`, `60m`, `90m`, `1h`, `1d`, `5d`, `1wk`,
+  `1mo`, `3mo`
+
+`lookback_days` wird intern zu einem `period`-String im Format `Nd`
+umgewandelt. Anstelle einer Tageszahl wären auch die
+Standardperioden von Yahoo Finance möglich:
+`1d`, `5d`, `1mo`, `3mo`, `6mo`, `1y`, `2y`, `5y`, `10y`, `ytd`, `max`.
+
+Bei Intervallen unterhalb von `1d` liefert Yahoo Finance lediglich Daten
+der letzten ca. 60 Tage.
+
 Während der Laufzeit speichert der Bot seinen Zustand in `output/live_trader_state.json`. Dort findest du den aktuellen Kurs, gleitende Durchschnitte, offene Positionen und die letzte Aktion.
 
 ## Starten des Bots


### PR DESCRIPTION
## Summary
- clarify valid time values for ElliottWaveBot
- document Yahoo Finance period/interval formats for LiveTraderBot

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685b34eb185c832a853ade3088009d23