### PR TITLE
Add LimitCycleBot simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ config/api/withdraw_db.json
 
 config/chatbot/elliott_wave_settings.json
 config/chatbot/live_trader_settings.json
+config/chatbot/limit_cycle_settings.json
+
+# Ignore generated output and data files
+output/
+data/
 
 # Misc
 *.log

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ fetches price data from both Kraken and Yahoo Finance and prints the values.
 Another demo called `ElliottWaveBot` performs a very rough Elliott wave
 analysis on historical prices and simulates trades based on configurable
 criteria.
+`LimitCycleBot` demonstrates repeated limit orders with a small portfolio and
+reports the last realised profit after each trade cycle.
 Start it from the main menu or directly via:
 
 ```bash
@@ -111,7 +113,9 @@ You can customise the trading pair and symbol before the bot runs. When
 starting the Elliott wave bot you may pass a settings file path to tweak
 parameters such as analysis period, price interval and profit margin.
 See [docs/elliott_wave_bot.md](docs/elliott_wave_bot.md) for a detailed
-description of the available options.
+description of the available options. Details about the limit order cycle
+strategy can be found in
+[docs/limit_cycle_bot.md](docs/limit_cycle_bot.md).
 
 ## Security Notes
 

--- a/config/chatbot/limit_cycle_settings.json.example
+++ b/config/chatbot/limit_cycle_settings.json.example
@@ -1,0 +1,11 @@
+{
+    "symbol": "BTC-USD",
+    "refresh_rate": 2,
+    "startbuy_threshold": 0.4,
+    "initial_portfolio_eur": 1000,
+    "reinvestment_percent": 15,
+    "take_profit_percent": 0.8,
+    "buyback_percent": 0.5,
+    "safety_offset": 0.15,
+    "debug": true
+}

--- a/docs/limit_cycle_bot.md
+++ b/docs/limit_cycle_bot.md
@@ -1,0 +1,43 @@
+# LimitCycleBot
+
+`LimitCycleBot` is a simple strategy that repeatedly places limit orders around the current price. The bot only simulates trades and prints regular status updates. Later it can be connected to the Kraken API.
+
+## Configuration
+
+Copy `config/chatbot/limit_cycle_settings.json.example` to `config/chatbot/limit_cycle_settings.json` and adjust the values:
+
+```json
+{
+    "symbol": "BTC-USD",
+    "refresh_rate": 2,
+    "startbuy_threshold": 0.4,
+    "initial_portfolio_eur": 1000,
+    "reinvestment_percent": 15,
+    "take_profit_percent": 0.8,
+    "buyback_percent": 0.5,
+    "safety_offset": 0.15,
+    "debug": true
+}
+```
+
+### Fields
+
+- **symbol** – Ticker symbol used for price retrieval via Yahoo Finance.
+- **refresh_rate** – Seconds between price checks.
+- **startbuy_threshold** – Percentage difference between the two initial buy orders.
+- **initial_portfolio_eur** – Euro amount used for the very first trade.
+- **reinvestment_percent** – Percentage of the current portfolio that is reinvested after each completed cycle.
+- **take_profit_percent** – Profit target above the last buy price before a sell order is placed.
+- **buyback_percent** – Price drop below the last sell price before a new buy is placed.
+- **safety_offset** – Offset applied to limit orders to increase the chance of execution.
+- **debug** – If `true`, the bot prints all status information to the console.
+
+## Running the bot
+
+Start the chatbot menu and select the LimitCycleBot or run it directly:
+
+```bash
+python -m modules.chatbot.limit_cycle_bot
+```
+
+The bot places two initial limit buy orders slightly above and below the current price. After one fills, it sets a take-profit sell order and later a new buy order. Each log output also shows the last realised profit once a full buy/sell cycle was completed.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -14,6 +14,7 @@ flowchart TD
     J --> K[modules/chatbot]
     K --> L[config/chatbot/elliott_wave_settings.json]
     K --> M[config/chatbot/live_trader_settings.json]
+    K --> N[config/chatbot/limit_cycle_settings.json]
 ```
 
 This diagram shows the high level components of the project and how they relate
@@ -23,4 +24,5 @@ Telegram bot.
 Additional strategy bots use JSON settings located in `config/chatbot/`. Along
 with the Elliott wave example you can configure a continuously running
 `LiveTraderBot` via `live_trader_settings.json` described in
-`docs/live_trader_bot.md`.
+`docs/live_trader_bot.md`. The new `LimitCycleBot` uses
+`limit_cycle_settings.json` and is documented in `docs/limit_cycle_bot.md`.

--- a/modules/chatbot/chatbot.py
+++ b/modules/chatbot/chatbot.py
@@ -3,6 +3,7 @@
 from .base import TickerBot
 from .elliott_wave_bot import ElliottWaveBot, Settings
 from .live_trader_bot import LiveTraderBot, LiveSettings
+from .limit_cycle_bot import LimitCycleBot, CycleSettings
 
 
 def run() -> None:
@@ -11,6 +12,7 @@ def run() -> None:
     print("1. Run ticker bot")
     print("2. Run Elliott wave bot")
     print("3. Run live trader bot")
+    print("4. Run limit cycle bot")
     print("99. Back")
     choice = input("Option: ") or "99"
     if choice == "1":
@@ -37,6 +39,16 @@ def run() -> None:
         )
         settings = LiveSettings.load(filename)
         bot = LiveTraderBot(settings)
+        bot.run()
+    elif choice == "4":
+        filename = (
+            input(
+                "Settings file (default: config/chatbot/limit_cycle_settings.json): "
+            )
+            or "config/chatbot/limit_cycle_settings.json"
+        )
+        settings = CycleSettings.load(filename)
+        bot = LimitCycleBot(settings)
         bot.run()
 
 

--- a/modules/chatbot/limit_cycle_bot.py
+++ b/modules/chatbot/limit_cycle_bot.py
@@ -1,0 +1,225 @@
+"""Simple limit order cycle bot for live price simulation."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from .base import BaseChatBot
+
+
+@dataclass
+class CycleSettings:
+    symbol: str = "BTC-USD"
+    refresh_rate: int = 2  # seconds
+    startbuy_threshold: float = 0.4  # total percent difference between start orders
+    initial_portfolio_eur: float = 1000.0
+    reinvestment_percent: float = 15.0
+    take_profit_percent: float = 0.8
+    buyback_percent: float = 0.5
+    safety_offset: float = 0.15
+    debug: bool = True
+
+    @staticmethod
+    def load(filename: str) -> "CycleSettings":
+        with open(filename, "r") as fh:
+            data = json.load(fh)
+        valid = {k: v for k, v in data.items() if k in CycleSettings.__annotations__}
+        return CycleSettings(**valid)
+
+
+@dataclass
+class LimitOrder:
+    side: str  # "buy" or "sell"
+    price: float
+    amount: float
+
+
+class LimitCycleBot(BaseChatBot):
+    """Trading bot that simulates recurring limit orders."""
+
+    def __init__(self, settings: CycleSettings) -> None:
+        self.settings = settings
+        self.eur_balance = settings.initial_portfolio_eur
+        self.asset_balance = 0.0
+        self.last_profit: Optional[dict] = None
+        self.current_buy_amount = settings.initial_portfolio_eur
+        self.last_buy_price: Optional[float] = None
+        self.open_buy_low: Optional[LimitOrder] = None
+        self.open_buy_high: Optional[LimitOrder] = None
+        self.open_sell: Optional[LimitOrder] = None
+        self.high_since_buy: Optional[float] = None
+        self.low_since_sell: Optional[float] = None
+        self.start_time = time.time()
+
+    # --- Helpers ---------------------------------------------------------
+    def _log(self, price: float) -> None:
+        current_value = self.eur_balance + self.asset_balance * price
+        elapsed = int(time.time() - self.start_time)
+        lines = [
+            f"[LOG {elapsed}s] Portfolio Status:",
+            f"Startkapital:        {self.settings.initial_portfolio_eur:.2f} €",
+            f"Aktueller Wert:      {current_value:.2f} €",
+            f"Eingesetzt:          {self.current_buy_amount:.2f} €",
+            f"Freies Kapital:      {self.eur_balance:.2f} €",
+        ]
+        if self.last_buy_price:
+            lines.append(f"Letzter Kaufkurs:    {self.last_buy_price:.4f} €")
+        lines.append("Offene Orders:")
+        if self.open_sell:
+            lines.append(
+                f"  – Sell @ {self.open_sell.price:.4f} € (Take Profit)"
+            )
+        if self.open_buy_low:
+            lines.append(f"  – Buy @ {self.open_buy_low.price:.4f} € (Rebuy)")
+        if self.settings.debug:
+            print("\n".join(lines))
+            if self.last_profit:
+                lp = self.last_profit
+                print(
+                    "\nLetzter Profit:\n"
+                    f"  Gekauft: {lp['buy_eur']:.2f} € @ {lp['buy_price']:.4f} €\n"
+                    f"  Verkauft: {lp['sell_eur']:.2f} € @ {lp['sell_price']:.4f} €\n"
+                    f"  Gewinn: {lp['profit_eur']:+.2f} € ({lp['profit_pct']:+.2f} %)"
+                )
+
+    def _place_start_orders(self, price: float) -> None:
+        diff = self.settings.startbuy_threshold / 100 / 2
+        low_price = price * (1 - diff)
+        high_price = price * (1 + diff)
+        amount = self.current_buy_amount / price
+        self.open_buy_low = LimitOrder("buy", low_price, amount)
+        self.open_buy_high = LimitOrder("buy", high_price, amount)
+        self.high_since_buy = None
+        self.low_since_sell = None
+        if self.settings.debug:
+            print(
+                f"Initial buy orders placed at {low_price:.4f} and {high_price:.4f} €"
+            )
+
+    def _update_sell_order(self, price: float) -> None:
+        if not self.open_sell:
+            return
+        if self.high_since_buy is None or price > self.high_since_buy:
+            self.high_since_buy = price
+            new_price = self.high_since_buy * (1 - self.settings.safety_offset / 100)
+            if new_price > self.open_sell.price:
+                if self.settings.debug:
+                    print(
+                        f"Adjusting sell order from {self.open_sell.price:.4f} to {new_price:.4f} €"
+                    )
+                self.open_sell.price = new_price
+        if price >= self.open_sell.price:
+            # execute sell
+            sell_price = self.open_sell.price
+            amount = self.open_sell.amount
+            eur_received = amount * sell_price
+            self.eur_balance += eur_received
+            self.asset_balance = 0.0
+            buy_eur = self.current_buy_amount
+            profit_eur = eur_received - buy_eur
+            profit_pct = profit_eur / buy_eur * 100
+            self.last_profit = {
+                "buy_eur": buy_eur,
+                "buy_price": self.last_buy_price,
+                "sell_eur": eur_received,
+                "sell_price": sell_price,
+                "profit_eur": profit_eur,
+                "profit_pct": profit_pct,
+            }
+            if self.settings.debug:
+                print(
+                    f"SELL executed at {sell_price:.4f} € for {eur_received:.2f} €"
+                )
+            self.open_sell = None
+            self.high_since_buy = None
+            # prepare next buy amount
+            self.current_buy_amount = (
+                (self.eur_balance) * self.settings.reinvestment_percent / 100
+            )
+            target_price = sell_price * (1 - self.settings.buyback_percent / 100)
+            buy_price = target_price * (1 + self.settings.safety_offset / 100)
+            amount = self.current_buy_amount / buy_price
+            self.open_buy_low = LimitOrder("buy", buy_price, amount)
+            if self.settings.debug:
+                print(
+                    f"Next buy order placed at {buy_price:.4f} € for {self.current_buy_amount:.2f} €"
+                )
+
+    def _update_buy_orders(self, price: float) -> None:
+        if self.open_buy_low and price < self.open_buy_low.price:
+            new_price = price * (1 + self.settings.safety_offset / 100)
+            if new_price < self.open_buy_low.price:
+                if self.settings.debug:
+                    print(
+                        f"Adjusting buy order from {self.open_buy_low.price:.4f} to {new_price:.4f} €"
+                    )
+                self.open_buy_low.price = new_price
+        if self.open_buy_low and price <= self.open_buy_low.price:
+            # execute buy
+            buy_price = self.open_buy_low.price
+            amount = self.open_buy_low.amount
+            cost = buy_price * amount
+            self.eur_balance -= cost
+            self.asset_balance += amount
+            self.last_buy_price = buy_price
+            if self.settings.debug:
+                print(
+                    f"BUY executed at {buy_price:.4f} € for {cost:.2f} €"
+                )
+            self.open_buy_low = None
+            self.open_buy_high = None
+            # create sell order
+            target_price = buy_price * (1 + self.settings.take_profit_percent / 100)
+            sell_price = target_price * (1 - self.settings.safety_offset / 100)
+            self.open_sell = LimitOrder("sell", sell_price, amount)
+            if self.settings.debug:
+                print(
+                    f"Sell order placed at {sell_price:.4f} € for target profit"
+                )
+        elif self.open_buy_high and price >= self.open_buy_high.price:
+            # execute high buy order
+            buy_price = self.open_buy_high.price
+            amount = self.open_buy_high.amount
+            cost = buy_price * amount
+            self.eur_balance -= cost
+            self.asset_balance += amount
+            self.last_buy_price = buy_price
+            if self.settings.debug:
+                print(
+                    f"BUY executed at {buy_price:.4f} € for {cost:.2f} €"
+                )
+            self.open_buy_low = None
+            self.open_buy_high = None
+            target_price = buy_price * (1 + self.settings.take_profit_percent / 100)
+            sell_price = target_price * (1 - self.settings.safety_offset / 100)
+            self.open_sell = LimitOrder("sell", sell_price, amount)
+            if self.settings.debug:
+                print(
+                    f"Sell order placed at {sell_price:.4f} € for target profit"
+                )
+
+    # --- Main loop -------------------------------------------------------
+    def run(self) -> None:
+        price = self.fetch_yahoo_price(self.settings.symbol)
+        if price is None:
+            print("Failed to fetch initial price")
+            return
+        self._place_start_orders(price)
+        while True:
+            price = self.fetch_yahoo_price(self.settings.symbol)
+            if price is None:
+                time.sleep(self.settings.refresh_rate)
+                continue
+            self._update_buy_orders(price)
+            self._update_sell_order(price)
+            self._log(price)
+            time.sleep(self.settings.refresh_rate)
+
+
+if __name__ == "__main__":
+    settings = CycleSettings.load("config/chatbot/limit_cycle_settings.json")
+    bot = LimitCycleBot(settings)
+    bot.run()


### PR DESCRIPTION
## Summary
- implement `LimitCycleBot` to simulate recurring limit orders
- add example configuration
- document the new bot and mention it in project overview and README
- add option in chatbot menu
- ignore generated data files in git

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685b4aa39f48832aa404de37370b47ab