### PR TITLE
Improve docs and logging

### DIFF
--- a/config/chatbot/elliott_wave_settings.json.example
+++ b/config/chatbot/elliott_wave_settings.json.example
@@ -1,8 +1,8 @@
 {
-    "symbol": "BTC-USD",
-    "period": "1y",
-    "interval": "1d",
-    "profit_pct": 2.0,
-    "start_balance": 1000,
-    "wave_threshold_pct": 2.5
+    "symbol": "BTC-USD",          // Yahoo Finance symbol
+    "period": "1y",                // amount of historical data
+    "interval": "1d",               // data resolution
+    "profit_pct": 2.0,              // profit goal per trade in percent
+    "start_balance": 1000,          // initial balance for simulation
+    "wave_threshold_pct": 2.5       // % move considered a wave
 }

--- a/config/chatbot/limit_cycle_settings.json.example
+++ b/config/chatbot/limit_cycle_settings.json.example
@@ -1,11 +1,12 @@
 {
-    "symbol": "BTC-USD",
-    "refresh_rate": 2,
-    "startbuy_threshold": 0.4,
-    "initial_portfolio_eur": 1000,
-    "reinvestment_percent": 15,
-    "take_profit_percent": 0.8,
-    "buyback_percent": 0.5,
-    "safety_offset": 0.15,
-    "debug": true
+    "symbol": "BTC-USD",            // Yahoo Finance symbol used for pricing
+    "refresh_rate": 2,              // Seconds between price checks
+    "startbuy_threshold": 0.4,      // % spread between the initial buy orders
+    "initial_portfolio_eur": 1000,  // Starting capital in Euro
+    "reinvestment_percent": 15,     // % of balance used for the next cycle
+    "take_profit_percent": 0.8,     // Desired profit before selling
+    "buyback_percent": 0.5,         // Price drop after a sell to trigger a buy
+    "safety_offset": 0.15,          // Extra margin for limit orders
+    "debug": true,                  // Print detailed logs
+    "log_interval": 1               // Log output every log_interval * refresh_rate seconds
 }

--- a/config/chatbot/live_trader_settings.json.example
+++ b/config/chatbot/live_trader_settings.json.example
@@ -1,12 +1,12 @@
 {
-    "symbol": "BTC-USD",
-    "lookback_days": 30,
-    "interval": "1h",
-    "trade_amount": 1000,
-    "profit_target_pct": 1.5,
-    "check_interval": 30,
-    "slope_window_minutes": 10,
-    "debug": true,
-    "telegram_enabled": false,
-    "telegram_settings_file": "config/telegram/bot_settings.json"
+    "symbol": "BTC-USD",                           // ticker symbol
+    "lookback_days": 30,                           // days of data to analyse
+    "interval": "1h",                              // candle interval
+    "trade_amount": 1000,                          // starting capital
+    "profit_target_pct": 1.5,                      // profit target per trade
+    "check_interval": 30,                          // seconds between checks
+    "slope_window_minutes": 10,                    // window for trend slope
+    "debug": true,                                 // verbose output
+    "telegram_enabled": false,                     // enable Telegram messages
+    "telegram_settings_file": "config/telegram/bot_settings.json" // Telegram config path
 }

--- a/docs/limit_cycle_bot.md
+++ b/docs/limit_cycle_bot.md
@@ -16,7 +16,8 @@ Copy `config/chatbot/limit_cycle_settings.json.example` to `config/chatbot/limit
     "take_profit_percent": 0.8,
     "buyback_percent": 0.5,
     "safety_offset": 0.15,
-    "debug": true
+    "debug": true,
+    "log_interval": 1
 }
 ```
 
@@ -31,6 +32,7 @@ Copy `config/chatbot/limit_cycle_settings.json.example` to `config/chatbot/limit
 - **buyback_percent** – Price drop below the last sell price before a new buy is placed.
 - **safety_offset** – Offset applied to limit orders to increase the chance of execution.
 - **debug** – If `true`, the bot prints all status information to the console.
+- **log_interval** – Number of refresh cycles between log outputs.
 
 ## Running the bot
 

--- a/modules/chatbot/elliott_wave_bot.py
+++ b/modules/chatbot/elliott_wave_bot.py
@@ -21,17 +21,23 @@ class Trade:
 
 @dataclass
 class Settings:
-    symbol: str = "BTC-USD"
-    period: str = "1y"
-    interval: str = "1d"
-    profit_pct: float = 2.0
-    start_balance: float = 1000.0
-    wave_threshold_pct: float = 2.5
+    symbol: str = "BTC-USD"  # Yahoo symbol
+    period: str = "1y"  # historical data period
+    interval: str = "1d"  # data interval
+    profit_pct: float = 2.0  # profit target per trade
+    start_balance: float = 1000.0  # initial capital for simulation
+    wave_threshold_pct: float = 2.5  # % move defining a wave
 
     @staticmethod
     def load(filename: str) -> "Settings":
         with open(filename, "r") as fh:
-            data = json.load(fh)
+            text = fh.read()
+        lines: list[str] = []
+        for line in text.splitlines():
+            line = line.split("//", 1)[0]
+            line = line.split("#", 1)[0]
+            lines.append(line)
+        data = json.loads("\n".join(lines))
         return Settings(**data)
 
 

--- a/modules/chatbot/limit_cycle_bot.py
+++ b/modules/chatbot/limit_cycle_bot.py
@@ -6,26 +6,34 @@ import json
 import time
 from dataclasses import dataclass
 from typing import Optional
+import re
 
 from .base import BaseChatBot
 
 
 @dataclass
 class CycleSettings:
-    symbol: str = "BTC-USD"
-    refresh_rate: int = 2  # seconds
-    startbuy_threshold: float = 0.4  # total percent difference between start orders
-    initial_portfolio_eur: float = 1000.0
-    reinvestment_percent: float = 15.0
-    take_profit_percent: float = 0.8
-    buyback_percent: float = 0.5
-    safety_offset: float = 0.15
-    debug: bool = True
+    symbol: str = "BTC-USD"  # Yahoo Finance symbol
+    refresh_rate: int = 2  # seconds between price checks
+    startbuy_threshold: float = 0.4  # % difference between initial buy orders
+    initial_portfolio_eur: float = 1000.0  # starting capital
+    reinvestment_percent: float = 15.0  # % of balance used after each cycle
+    take_profit_percent: float = 0.8  # target profit before selling
+    buyback_percent: float = 0.5  # drop from sell price before rebuy
+    safety_offset: float = 0.15  # margin on limit orders
+    debug: bool = True  # print debug information
+    log_interval: int = 1  # number of refresh cycles between log output
 
     @staticmethod
     def load(filename: str) -> "CycleSettings":
         with open(filename, "r") as fh:
-            data = json.load(fh)
+            text = fh.read()
+        lines = []
+        for line in text.splitlines():
+            line = line.split("//", 1)[0]
+            line = line.split("#", 1)[0]
+            lines.append(line)
+        data = json.loads("\n".join(lines))
         valid = {k: v for k, v in data.items() if k in CycleSettings.__annotations__}
         return CycleSettings(**valid)
 
@@ -53,8 +61,22 @@ class LimitCycleBot(BaseChatBot):
         self.high_since_buy: Optional[float] = None
         self.low_since_sell: Optional[float] = None
         self.start_time = time.time()
+        self.log_counter = 0
 
     # --- Helpers ---------------------------------------------------------
+    def _waiting_for(self) -> str:
+        if self.open_sell:
+            return f"sell >= {self.open_sell.price:.4f} €"
+        if self.open_buy_low and self.open_buy_high:
+            return (
+                f"buy <= {self.open_buy_low.price:.4f} € or >= {self.open_buy_high.price:.4f} €"
+            )
+        if self.open_buy_low:
+            return f"buy <= {self.open_buy_low.price:.4f} €"
+        if self.open_buy_high:
+            return f"buy >= {self.open_buy_high.price:.4f} €"
+        return "new cycle"
+
     def _log(self, price: float) -> None:
         current_value = self.eur_balance + self.asset_balance * price
         elapsed = int(time.time() - self.start_time)
@@ -74,6 +96,7 @@ class LimitCycleBot(BaseChatBot):
             )
         if self.open_buy_low:
             lines.append(f"  – Buy @ {self.open_buy_low.price:.4f} € (Rebuy)")
+        lines.append(f"Warte auf: {self._waiting_for()}")
         if self.settings.debug:
             print("\n".join(lines))
             if self.last_profit:
@@ -215,7 +238,9 @@ class LimitCycleBot(BaseChatBot):
                 continue
             self._update_buy_orders(price)
             self._update_sell_order(price)
-            self._log(price)
+            self.log_counter += 1
+            if self.log_counter % self.settings.log_interval == 0:
+                self._log(price)
             time.sleep(self.settings.refresh_rate)
 
 

--- a/modules/chatbot/live_trader_bot.py
+++ b/modules/chatbot/live_trader_bot.py
@@ -16,21 +16,27 @@ import yfinance as yf
 class LiveSettings:
     """Configuration for :class:`LiveTraderBot`."""
 
-    symbol: str = "BTC-USD"
-    lookback_days: int = 30
-    interval: str = "1h"
-    trade_amount: float = 1000.0
-    profit_target_pct: float = 1.5
-    check_interval: int = 30
-    slope_window_minutes: int = 10
-    debug: bool = True
-    telegram_enabled: bool = False
-    telegram_settings_file: str = "config/telegram/bot_settings.json"
+    symbol: str = "BTC-USD"  # ticker symbol
+    lookback_days: int = 30  # days of data to analyse
+    interval: str = "1h"  # data granularity
+    trade_amount: float = 1000.0  # amount used per trade
+    profit_target_pct: float = 1.5  # desired profit percentage
+    check_interval: int = 30  # seconds between price checks
+    slope_window_minutes: int = 10  # trend calculation window
+    debug: bool = True  # verbose output
+    telegram_enabled: bool = False  # send updates via telegram
+    telegram_settings_file: str = "config/telegram/bot_settings.json"  # telegram config
 
     @staticmethod
     def load(filename: str) -> "LiveSettings":
         with open(filename, "r") as fh:
-            data = json.load(fh)
+            text = fh.read()
+        lines: list[str] = []
+        for line in text.splitlines():
+            line = line.split("//", 1)[0]
+            line = line.split("#", 1)[0]
+            lines.append(line)
+        data = json.loads("\n".join(lines))
         valid = {k: v for k, v in data.items() if k in LiveSettings.__annotations__}
         return LiveSettings(**valid)
 


### PR DESCRIPTION
## Summary
- document chatbot configs inline via comments
- make config loaders support commented JSON
- add new `log_interval` setting for LimitCycleBot
- show current waiting state in log output

## Testing
- `python -m compileall -q modules/chatbot`
- `python -m py_compile modules/chatbot/*.py`

------
https://chatgpt.com/codex/tasks/task_b_685b4e3d2d5c832a8eda9e4effd1bd8b