### PR TITLE
Remove comments from JSON example configs

### DIFF
--- a/config/chatbot/elliott_wave_settings.json.example
+++ b/config/chatbot/elliott_wave_settings.json.example
@@ -1,8 +1,8 @@
 {
-    "symbol": "BTC-USD",          // Yahoo Finance symbol
-    "period": "1y",                // amount of historical data
-    "interval": "1d",               // data resolution
-    "profit_pct": 2.0,              // profit goal per trade in percent
-    "start_balance": 1000,          // initial balance for simulation
-    "wave_threshold_pct": 2.5       // % move considered a wave
+    "symbol": "BTC-USD",
+    "period": "1y",
+    "interval": "1d",
+    "profit_pct": 2.0,
+    "start_balance": 1000,
+    "wave_threshold_pct": 2.5
 }

--- a/config/chatbot/limit_cycle_settings.json.example
+++ b/config/chatbot/limit_cycle_settings.json.example
@@ -1,12 +1,12 @@
 {
-    "symbol": "BTC-USD",            // Yahoo Finance symbol used for pricing
-    "refresh_rate": 2,              // Seconds between price checks
-    "startbuy_threshold": 0.4,      // % spread between the initial buy orders
-    "initial_portfolio_eur": 1000,  // Starting capital in Euro
-    "reinvestment_percent": 15,     // % of balance used for the next cycle
-    "take_profit_percent": 0.8,     // Desired profit before selling
-    "buyback_percent": 0.5,         // Price drop after a sell to trigger a buy
-    "safety_offset": 0.15,          // Extra margin for limit orders
-    "debug": true,                  // Print detailed logs
-    "log_interval": 1               // Log output every log_interval * refresh_rate seconds
+    "symbol": "BTC-USD",
+    "refresh_rate": 2,
+    "startbuy_threshold": 0.4,
+    "initial_portfolio_eur": 1000,
+    "reinvestment_percent": 15,
+    "take_profit_percent": 0.8,
+    "buyback_percent": 0.5,
+    "safety_offset": 0.15,
+    "debug": true,
+    "log_interval": 1
 }

--- a/config/chatbot/live_trader_settings.json.example
+++ b/config/chatbot/live_trader_settings.json.example
@@ -1,12 +1,12 @@
 {
-    "symbol": "BTC-USD",                           // ticker symbol
-    "lookback_days": 30,                           // days of data to analyse
-    "interval": "1h",                              // candle interval
-    "trade_amount": 1000,                          // starting capital
-    "profit_target_pct": 1.5,                      // profit target per trade
-    "check_interval": 30,                          // seconds between checks
-    "slope_window_minutes": 10,                    // window for trend slope
-    "debug": true,                                 // verbose output
-    "telegram_enabled": false,                     // enable Telegram messages
-    "telegram_settings_file": "config/telegram/bot_settings.json" // Telegram config path
+    "symbol": "BTC-USD",
+    "lookback_days": 30,
+    "interval": "1h",
+    "trade_amount": 1000,
+    "profit_target_pct": 1.5,
+    "check_interval": 30,
+    "slope_window_minutes": 10,
+    "debug": true,
+    "telegram_enabled": false,
+    "telegram_settings_file": "config/telegram/bot_settings.json"
 }


### PR DESCRIPTION
## Summary
- clean up JSON example configuration files by removing inline `//` comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b50620924832a986e1b11ae23ee31