### PR TITLE
Improve order and request logging

### DIFF
--- a/lib/lib.py
+++ b/lib/lib.py
@@ -10,6 +10,12 @@ from PyQt5.QtWidgets import QApplication, QFileDialog
 lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, lib_path)
 
+
+def highlight_message(message: str) -> None:
+    """Print a highlighted message for better visibility."""
+    line = "=" * len(message)
+    print(f"\n{line}\n{message}\n{line}\n")
+
 #######################################################################
 ############################ functions ################################
 #######################################################################

--- a/modules/chatbot/limit_cycle_bot.py
+++ b/modules/chatbot/limit_cycle_bot.py
@@ -9,6 +9,7 @@ from typing import Optional
 import re
 
 from .base import BaseChatBot
+import lib.lib as lib
 
 
 @dataclass
@@ -125,7 +126,7 @@ class LimitCycleBot(BaseChatBot):
         self.high_since_buy = None
         self.low_since_sell = None
         if self.settings.debug:
-            print(
+            lib.highlight_message(
                 f"Initial buy orders placed at {low_price:.4f} and {high_price:.4f} €"
             )
 
@@ -160,7 +161,7 @@ class LimitCycleBot(BaseChatBot):
                 "profit_pct": profit_pct,
             }
             if self.settings.debug:
-                print(
+                lib.highlight_message(
                     f"SELL executed at {sell_price:.4f} € for {eur_received:.2f} €"
                 )
             self.open_sell = None
@@ -174,7 +175,7 @@ class LimitCycleBot(BaseChatBot):
             amount = self.current_buy_amount / buy_price
             self.open_buy_low = LimitOrder("buy", buy_price, amount)
             if self.settings.debug:
-                print(
+                lib.highlight_message(
                     f"Next buy order placed at {buy_price:.4f} € for {self.current_buy_amount:.2f} €"
                 )
 
@@ -196,7 +197,7 @@ class LimitCycleBot(BaseChatBot):
             self.asset_balance += amount
             self.last_buy_price = buy_price
             if self.settings.debug:
-                print(
+                lib.highlight_message(
                     f"BUY executed at {buy_price:.4f} € for {cost:.2f} €"
                 )
             self.open_buy_low = None
@@ -206,7 +207,7 @@ class LimitCycleBot(BaseChatBot):
             sell_price = target_price * (1 - self.settings.safety_offset / 100)
             self.open_sell = LimitOrder("sell", sell_price, amount)
             if self.settings.debug:
-                print(
+                lib.highlight_message(
                     f"Sell order placed at {sell_price:.4f} € for target profit"
                 )
         elif self.open_buy_high and price >= self.open_buy_high.price:
@@ -218,7 +219,7 @@ class LimitCycleBot(BaseChatBot):
             self.asset_balance += amount
             self.last_buy_price = buy_price
             if self.settings.debug:
-                print(
+                lib.highlight_message(
                     f"BUY executed at {buy_price:.4f} € for {cost:.2f} €"
                 )
             self.open_buy_low = None
@@ -227,7 +228,7 @@ class LimitCycleBot(BaseChatBot):
             sell_price = target_price * (1 - self.settings.safety_offset / 100)
             self.open_sell = LimitOrder("sell", sell_price, amount)
             if self.settings.debug:
-                print(
+                lib.highlight_message(
                     f"Sell order placed at {sell_price:.4f} € for target profit"
                 )
 

--- a/modules/kraken_request/kraken_request.py
+++ b/modules/kraken_request/kraken_request.py
@@ -30,6 +30,7 @@ def run(api_name: str) -> None:
             _run_user_data(api_key, api_sec)
         elif option == 7:
             pair = input("Ticker pair (default: XBTUSD): ") or "XBTUSD"
+            lib.highlight_message(f"Requesting ticker for {pair}")
             data = kraken_api.ticker(pair)
             lib.display_data(data)
         elif option == 99:
@@ -48,6 +49,8 @@ def _run_user_data(api_key: str, api_sec: str) -> None:
             print("Ungültige Eingabe")
             continue
         try:
+            action_name = menu_settings.user_data_menu_items.get(option, "Request")
+            lib.highlight_message(f"Executing {action_name}")
             data = func(api_key, api_sec)
             # pick display function depending on result shape
             result = data.get("result") if isinstance(data, dict) else None


### PR DESCRIPTION
## Summary
- add new `highlight_message` helper for standout messages
- show clearly when LimitCycleBot places or executes orders
- highlight executed requests in interactive Kraken tool

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685b54be2420832a8ec2c2d92dcad248