### PR TITLE
Improve limit cycle bot logging

### DIFF
--- a/config/chatbot/limit_cycle_settings.json.example
+++ b/config/chatbot/limit_cycle_settings.json.example
@@ -11,5 +11,6 @@
     "stop_loss_percent": 2.0,
     "debug": true,
     "log_interval_terminal": 1,
-    "log_interval_file": 1
+    "log_interval_file": 1,
+    "auto_log": true
 }

--- a/docs/limit_cycle_bot.md
+++ b/docs/limit_cycle_bot.md
@@ -20,7 +20,8 @@ Copy `config/chatbot/limit_cycle_settings.json.example` to `config/chatbot/limit
     "stop_loss_percent": 2.0,
     "debug": true,
     "log_interval_terminal": 1,
-    "log_interval_file": 1
+    "log_interval_file": 1,
+    "auto_log": true
 }
 ```
 
@@ -39,6 +40,7 @@ Copy `config/chatbot/limit_cycle_settings.json.example` to `config/chatbot/limit
 - **debug** – If `true`, the bot prints all status information to the console.
 - **log_interval_terminal** – Number of refresh cycles between terminal log outputs.
 - **log_interval_file** – Number of refresh cycles between file log entries.
+- **auto_log** – If `true`, log output appears only when portfolio values change; when `false`, logs are printed on every interval.
 
 ## Running the bot
 

--- a/modules/chatbot/limit_cycle_bot.py
+++ b/modules/chatbot/limit_cycle_bot.py
@@ -28,6 +28,7 @@ class CycleSettings:
     debug: bool = True  # print debug information
     log_interval_terminal: int = 1  # number of refresh cycles between terminal log output
     log_interval_file: int = 1  # number of refresh cycles between file log output
+    auto_log: bool = True  # only output logs when values change
 
     @staticmethod
     def load(filename: str) -> "CycleSettings":
@@ -69,8 +70,23 @@ class LimitCycleBot(BaseChatBot):
         self.start_time = time.time()
         self.log_counter = 0
         self.log_file_path = ""
+        self._last_snapshot_terminal: Optional[dict] = None
+        self._last_snapshot_file: Optional[dict] = None
 
     # --- Helpers ---------------------------------------------------------
+    def _create_snapshot(self, price: float) -> dict:
+        """Return the current state values for change detection."""
+        return {
+            "price": round(price, 4),
+            "eur_balance": round(self.eur_balance, 2),
+            "asset_balance": round(self.asset_balance, 8),
+            "current_buy_amount": round(self.current_buy_amount, 2),
+            "last_buy_price": round(self.last_buy_price, 4) if self.last_buy_price else None,
+            "open_buy_low": round(self.open_buy_low.price, 4) if self.open_buy_low else None,
+            "open_buy_high": round(self.open_buy_high.price, 4) if self.open_buy_high else None,
+            "open_sell": round(self.open_sell.price, 4) if self.open_sell else None,
+            "open_stop_loss": round(self.open_stop_loss.price, 4) if self.open_stop_loss else None,
+        }
     def _waiting_for(self) -> str:
         if self.open_stop_loss:
             return f"stop loss <= {self.open_stop_loss.price:.4f} €"
@@ -87,7 +103,22 @@ class LimitCycleBot(BaseChatBot):
         return "new cycle"
 
     def _log(self, price: float, *, to_terminal: bool = True, to_file: bool = False) -> None:
-        """Output portfolio status to terminal and/or file."""
+        """Output portfolio status to terminal and/or file.
+
+        When ``settings.auto_log`` is True, logs are printed only when any
+        tracked numeric value changed since the last output for the respective
+        destination.
+        """
+        snapshot = self._create_snapshot(price)
+        if to_terminal:
+            if self.settings.auto_log and snapshot == self._last_snapshot_terminal:
+                return
+            self._last_snapshot_terminal = snapshot.copy()
+        if to_file:
+            if self.settings.auto_log and snapshot == self._last_snapshot_file:
+                return
+            self._last_snapshot_file = snapshot.copy()
+
         current_value = self.eur_balance + self.asset_balance * price
         elapsed = int(time.time() - self.start_time)
         lines = [
@@ -133,12 +164,14 @@ class LimitCycleBot(BaseChatBot):
             print("\n".join(lines))
             if profit_lines:
                 print("\n".join(profit_lines))
+            print()
 
         if to_file:
             with open(self.log_file_path, "a") as fh:
                 fh.write("\n".join(lines) + "\n")
                 if profit_lines:
                     fh.write("\n".join(profit_lines) + "\n")
+                fh.write("\n")
 
     def _execute_sell(self, sell_price: float, amount: float, stop_loss: bool = False) -> None:
         eur_received = amount * sell_price


### PR DESCRIPTION
## Summary
- enhance `LimitCycleBot` logging
- only log portfolio info when any numeric state has changed
- ensure each terminal or file log entry is separated by a blank line
- add `auto_log` setting to toggle state-change detection

## Testing
- `python -m py_compile modules/chatbot/limit_cycle_bot.py`

------
https://chatgpt.com/codex/tasks/task_b_685b5e5fc370832a84bd69010ef7a7e5