### PR TITLE
Enable Kraken API price source for LimitCycleBot

### DIFF
--- a/config/chatbot/limit_cycle_settings.json.example
+++ b/config/chatbot/limit_cycle_settings.json.example
@@ -1,5 +1,7 @@
 {
     "symbol": "BTC-USD",
+    "pair": "XBTEUR",
+    "use_kraken_price": false,
     "refresh_rate": 2,
     "startbuy_threshold": 0.4,
     "initial_portfolio_eur": 1000,

--- a/docs/limit_cycle_bot.md
+++ b/docs/limit_cycle_bot.md
@@ -9,6 +9,8 @@ Copy `config/chatbot/limit_cycle_settings.json.example` to `config/chatbot/limit
 ```json
 {
     "symbol": "BTC-USD",
+    "pair": "XBTEUR",
+    "use_kraken_price": false,
     "refresh_rate": 2,
     "startbuy_threshold": 0.4,
     "initial_portfolio_eur": 1000,
@@ -25,9 +27,11 @@ Copy `config/chatbot/limit_cycle_settings.json.example` to `config/chatbot/limit
 }
 ```
 
-### Fields
+-### Fields
 
 - **symbol** – Ticker symbol used for price retrieval via Yahoo Finance.
+- **pair** – Kraken trading pair used when fetching prices from the API.
+- **use_kraken_price** – If `true`, the bot retrieves the latest price from Kraken.
 - **refresh_rate** – Seconds between price checks.
 - **startbuy_threshold** – Percentage above the current price for the initial buy order.
 - **initial_portfolio_eur** – Euro amount used for the very first trade.

--- a/modules/chatbot/limit_cycle_bot.py
+++ b/modules/chatbot/limit_cycle_bot.py
@@ -16,6 +16,8 @@ import lib.lib as lib
 @dataclass
 class CycleSettings:
     symbol: str = "BTC-USD"  # Yahoo Finance symbol
+    pair: str = "XBTEUR"  # Kraken trading pair
+    use_kraken_price: bool = False  # fetch price from Kraken instead of Yahoo
     refresh_rate: int = 2  # seconds between price checks
     startbuy_threshold: float = 0.4  # % difference between initial buy orders
     initial_portfolio_eur: float = 1000.0  # starting capital
@@ -74,6 +76,20 @@ class LimitCycleBot(BaseChatBot):
         self._last_snapshot_file: Optional[dict] = None
 
     # --- Helpers ---------------------------------------------------------
+    def _get_price(self) -> float | None:
+        """Return the latest price from the configured source."""
+        if self.settings.use_kraken_price:
+            data = self.fetch_kraken_ticker(self.settings.pair)
+            if not data or data.get("error"):
+                return None
+            result = data.get("result")
+            if not result:
+                return None
+            info = next(iter(result.values()))
+            last = info.get("c", [None])[0]
+            return float(last) if last is not None else None
+        return self.fetch_yahoo_price(self.settings.symbol)
+
     def _create_snapshot(self, price: float) -> dict:
         """Return the current state values for change detection."""
         return {
@@ -121,9 +137,12 @@ class LimitCycleBot(BaseChatBot):
 
         current_value = self.eur_balance + self.asset_balance * price
         elapsed = int(time.time() - self.start_time)
+        asset_label = (
+            self.settings.pair if self.settings.use_kraken_price else self.settings.symbol
+        )
         lines = [
             f"[LOG {elapsed}s] Portfolio Status:",
-            f"Asset:               {self.settings.symbol}",
+            f"Asset:               {asset_label}",
             f"Aktueller Kurs:      {price:.4f} €",
             f"Startkapital:        {self.settings.initial_portfolio_eur:.2f} €",
             f"Aktueller Wert:      {current_value:.2f} €",
@@ -132,6 +151,8 @@ class LimitCycleBot(BaseChatBot):
         ]
         if self.asset_balance > 0:
             asset = self.settings.symbol.split("-")[0]
+            if self.settings.use_kraken_price:
+                asset = self.settings.pair[:3]
             lines.append(f"Bestand:            {self.asset_balance:.8f} {asset}")
         if self.last_buy_price:
             lines.append(f"Letzter Kaufkurs:    {self.last_buy_price:.4f} €")
@@ -328,14 +349,14 @@ class LimitCycleBot(BaseChatBot):
 
         reason = "completed"
         try:
-            price = self.fetch_yahoo_price(self.settings.symbol)
+            price = self._get_price()
             if price is None:
                 print("Failed to fetch initial price")
                 reason = "failed to fetch initial price"
                 return
             self._place_start_orders(price)
             while True:
-                price = self.fetch_yahoo_price(self.settings.symbol)
+                price = self._get_price()
                 if price is None:
                     time.sleep(self.settings.refresh_rate)
                     continue


### PR DESCRIPTION
## Summary
- add `pair` and `use_kraken_price` fields to `CycleSettings`
- fetch price via new `_get_price()` helper that can call Kraken API
- update settings example and documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m modules.chatbot.limit_cycle_bot` *(fails: ModuleNotFoundError: No module named 'yfinance')*

------
https://chatgpt.com/codex/tasks/task_b_685b66259830832a8188fc1ec65ad723