### PR TITLE
Add cumulative profit display in LimitCycleBot

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Another demo called `ElliottWaveBot` performs a very rough Elliott wave
 analysis on historical prices and simulates trades based on configurable
 criteria.
 `LimitCycleBot` demonstrates repeated limit orders with a small portfolio and
-reports the last realised profit after each trade cycle.
+reports both the last realised profit and the running total after each trade cycle.
 Start it from the main menu or directly via:
 
 ```bash

--- a/docs/limit_cycle_bot.md
+++ b/docs/limit_cycle_bot.md
@@ -54,4 +54,4 @@ Start the chatbot menu and select the LimitCycleBot or run it directly:
 python -m modules.chatbot.limit_cycle_bot
 ```
 
-The bot starts with a limit buy order slightly above the current price. After it fills, a stop-loss order is placed immediately. The take-profit sell order is only created once the price first reaches the configured target and then trails the price upwards. Once the position is closed, a new buy order is prepared. Each log output also shows the last realised profit once a full buy/sell cycle was completed.
+The bot starts with a limit buy order slightly above the current price. After it fills, a stop-loss order is placed immediately. The take-profit sell order is only created once the price first reaches the configured target and then trails the price upwards. Once the position is closed, a new buy order is prepared. Each log output shows the last realised profit and the accumulated *Gesamtgewinn* across all cycles.

--- a/modules/chatbot/limit_cycle_bot.py
+++ b/modules/chatbot/limit_cycle_bot.py
@@ -61,6 +61,7 @@ class LimitCycleBot(BaseChatBot):
         self.eur_balance = settings.initial_portfolio_eur
         self.asset_balance = 0.0
         self.last_profit: Optional[dict] = None
+        self.total_profit: float = 0.0
         self.current_buy_amount = settings.initial_portfolio_eur
         self.last_buy_price: Optional[float] = None
         self.open_buy_low: Optional[LimitOrder] = None
@@ -97,6 +98,7 @@ class LimitCycleBot(BaseChatBot):
             "eur_balance": round(self.eur_balance, 2),
             "asset_balance": round(self.asset_balance, 8),
             "current_buy_amount": round(self.current_buy_amount, 2),
+            "total_profit": round(self.total_profit, 2),
             "last_buy_price": round(self.last_buy_price, 4) if self.last_buy_price else None,
             "open_buy_low": round(self.open_buy_low.price, 4) if self.open_buy_low else None,
             "open_buy_high": round(self.open_buy_high.price, 4) if self.open_buy_high else None,
@@ -181,10 +183,13 @@ class LimitCycleBot(BaseChatBot):
                 f"  Gewinn: {lp['profit_eur']:+.2f} € ({lp['profit_pct']:+.2f} %)",
             ]
 
+        total_line = f"Gesamtgewinn: {self.total_profit:+.2f} €"
+
         if to_terminal and self.settings.debug:
             print("\n".join(lines))
             if profit_lines:
                 print("\n".join(profit_lines))
+            print(total_line)
             print()
 
         if to_file:
@@ -192,6 +197,7 @@ class LimitCycleBot(BaseChatBot):
                 fh.write("\n".join(lines) + "\n")
                 if profit_lines:
                     fh.write("\n".join(profit_lines) + "\n")
+                fh.write(total_line + "\n")
                 fh.write("\n")
 
     def _execute_sell(self, sell_price: float, amount: float, stop_loss: bool = False) -> None:
@@ -201,6 +207,7 @@ class LimitCycleBot(BaseChatBot):
         buy_eur = self.current_buy_amount
         profit_eur = eur_received - buy_eur
         profit_pct = profit_eur / buy_eur * 100
+        self.total_profit += profit_eur
         self.last_profit = {
             "buy_eur": buy_eur,
             "buy_price": self.last_buy_price,


### PR DESCRIPTION
## Summary
- show cumulative profit for LimitCycleBot and persist it in log snapshots
- document the new feature in README and docs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python -m py_compile modules/chatbot/limit_cycle_bot.py`


------
https://chatgpt.com/codex/tasks/task_b_685c525b7240832ab3ad51f9d41f9e75