### PR TITLE
Add EUR prices for Yahoo symbols

### DIFF
--- a/config/chatbot/elliott_wave_settings.json.example
+++ b/config/chatbot/elliott_wave_settings.json.example
@@ -1,5 +1,5 @@
 {
-    "symbol": "BTC-USD",
+    "symbol": "BTC-EUR",
     "period": "1y",
     "interval": "1d",
     "profit_pct": 2.0,

--- a/config/chatbot/limit_cycle_settings.json.example
+++ b/config/chatbot/limit_cycle_settings.json.example
@@ -1,5 +1,5 @@
 {
-    "symbol": "BTC-USD",
+    "symbol": "BTC-EUR",
     "pair": "XBTEUR",
     "use_kraken_price": false,
     "refresh_rate": 2,

--- a/config/chatbot/live_trader_settings.json.example
+++ b/config/chatbot/live_trader_settings.json.example
@@ -1,5 +1,5 @@
 {
-    "symbol": "BTC-USD",
+    "symbol": "BTC-EUR",
     "lookback_days": 30,
     "interval": "1h",
     "trade_amount": 1000,

--- a/config/chatbot/tests/cycle_settings_0000.json
+++ b/config/chatbot/tests/cycle_settings_0000.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.32,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 23,
+  "take_profit_percent": 1.73,
+  "buyback_percent": 0.5,
+  "safety_offset": 0.32,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.26,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0001.json
+++ b/config/chatbot/tests/cycle_settings_0001.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.67,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 16,
+  "take_profit_percent": 1.78,
+  "buyback_percent": 0.79,
+  "safety_offset": 0.37,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.36,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0002.json
+++ b/config/chatbot/tests/cycle_settings_0002.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.95,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 15,
+  "take_profit_percent": 0.76,
+  "buyback_percent": 0.62,
+  "safety_offset": 0.32,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.77,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0003.json
+++ b/config/chatbot/tests/cycle_settings_0003.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.32,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 15,
+  "take_profit_percent": 1.93,
+  "buyback_percent": 0.58,
+  "safety_offset": 0.49,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.56,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0004.json
+++ b/config/chatbot/tests/cycle_settings_0004.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.35,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 21,
+  "take_profit_percent": 0.66,
+  "buyback_percent": 0.53,
+  "safety_offset": 0.11,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.53,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0005.json
+++ b/config/chatbot/tests/cycle_settings_0005.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.23,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 30,
+  "take_profit_percent": 0.93,
+  "buyback_percent": 0.94,
+  "safety_offset": 0.39,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.58,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0006.json
+++ b/config/chatbot/tests/cycle_settings_0006.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.42,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 23,
+  "take_profit_percent": 0.7,
+  "buyback_percent": 0.97,
+  "safety_offset": 0.36,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.08,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0007.json
+++ b/config/chatbot/tests/cycle_settings_0007.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.59,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 18,
+  "take_profit_percent": 1.46,
+  "buyback_percent": 0.45,
+  "safety_offset": 0.35,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.6,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0008.json
+++ b/config/chatbot/tests/cycle_settings_0008.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.92,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 11,
+  "take_profit_percent": 1.85,
+  "buyback_percent": 0.86,
+  "safety_offset": 0.32,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.62,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0009.json
+++ b/config/chatbot/tests/cycle_settings_0009.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.26,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 15,
+  "take_profit_percent": 0.52,
+  "buyback_percent": 0.78,
+  "safety_offset": 0.39,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.07,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0010.json
+++ b/config/chatbot/tests/cycle_settings_0010.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.52,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 21,
+  "take_profit_percent": 1.87,
+  "buyback_percent": 0.7,
+  "safety_offset": 0.13,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.33,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0011.json
+++ b/config/chatbot/tests/cycle_settings_0011.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.74,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 28,
+  "take_profit_percent": 1.33,
+  "buyback_percent": 0.42,
+  "safety_offset": 0.17,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.06,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0012.json
+++ b/config/chatbot/tests/cycle_settings_0012.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.51,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 23,
+  "take_profit_percent": 1.6,
+  "buyback_percent": 0.32,
+  "safety_offset": 0.36,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 1.58,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0013.json
+++ b/config/chatbot/tests/cycle_settings_0013.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.3,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 30,
+  "take_profit_percent": 1.89,
+  "buyback_percent": 0.87,
+  "safety_offset": 0.22,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.9,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0014.json
+++ b/config/chatbot/tests/cycle_settings_0014.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.32,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 11,
+  "take_profit_percent": 1.09,
+  "buyback_percent": 0.32,
+  "safety_offset": 0.16,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.51,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0015.json
+++ b/config/chatbot/tests/cycle_settings_0015.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.34,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 15,
+  "take_profit_percent": 1.25,
+  "buyback_percent": 0.84,
+  "safety_offset": 0.15,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.38,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0016.json
+++ b/config/chatbot/tests/cycle_settings_0016.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.9,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 29,
+  "take_profit_percent": 1.38,
+  "buyback_percent": 0.71,
+  "safety_offset": 0.43,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.83,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0017.json
+++ b/config/chatbot/tests/cycle_settings_0017.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.77,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 23,
+  "take_profit_percent": 1.37,
+  "buyback_percent": 0.78,
+  "safety_offset": 0.15,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.88,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0018.json
+++ b/config/chatbot/tests/cycle_settings_0018.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.77,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 30,
+  "take_profit_percent": 1.08,
+  "buyback_percent": 0.73,
+  "safety_offset": 0.1,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.42,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0019.json
+++ b/config/chatbot/tests/cycle_settings_0019.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "BTC-EUR",
+  "pair": "XBTEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.22,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 14,
+  "take_profit_percent": 1.41,
+  "buyback_percent": 0.58,
+  "safety_offset": 0.46,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.48,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0020.json
+++ b/config/chatbot/tests/cycle_settings_0020.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.3,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 12,
+  "take_profit_percent": 1.63,
+  "buyback_percent": 0.41,
+  "safety_offset": 0.22,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.98,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0021.json
+++ b/config/chatbot/tests/cycle_settings_0021.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.29,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 18,
+  "take_profit_percent": 0.73,
+  "buyback_percent": 0.82,
+  "safety_offset": 0.4,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.08,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0022.json
+++ b/config/chatbot/tests/cycle_settings_0022.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.76,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 28,
+  "take_profit_percent": 1.4,
+  "buyback_percent": 0.89,
+  "safety_offset": 0.19,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.38,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0023.json
+++ b/config/chatbot/tests/cycle_settings_0023.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.36,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 11,
+  "take_profit_percent": 0.71,
+  "buyback_percent": 0.95,
+  "safety_offset": 0.14,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.97,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0024.json
+++ b/config/chatbot/tests/cycle_settings_0024.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.8,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 14,
+  "take_profit_percent": 0.58,
+  "buyback_percent": 0.95,
+  "safety_offset": 0.28,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.45,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0025.json
+++ b/config/chatbot/tests/cycle_settings_0025.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.32,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 28,
+  "take_profit_percent": 1.51,
+  "buyback_percent": 0.35,
+  "safety_offset": 0.46,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.93,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0026.json
+++ b/config/chatbot/tests/cycle_settings_0026.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.6,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 20,
+  "take_profit_percent": 1.31,
+  "buyback_percent": 0.31,
+  "safety_offset": 0.32,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.01,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0027.json
+++ b/config/chatbot/tests/cycle_settings_0027.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.61,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 29,
+  "take_profit_percent": 0.61,
+  "buyback_percent": 0.49,
+  "safety_offset": 0.33,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.86,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0028.json
+++ b/config/chatbot/tests/cycle_settings_0028.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.49,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 14,
+  "take_profit_percent": 1.61,
+  "buyback_percent": 0.43,
+  "safety_offset": 0.44,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.89,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0029.json
+++ b/config/chatbot/tests/cycle_settings_0029.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.52,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 12,
+  "take_profit_percent": 1.24,
+  "buyback_percent": 0.54,
+  "safety_offset": 0.16,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.8,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0030.json
+++ b/config/chatbot/tests/cycle_settings_0030.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.88,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 29,
+  "take_profit_percent": 1.43,
+  "buyback_percent": 0.71,
+  "safety_offset": 0.12,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.08,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0031.json
+++ b/config/chatbot/tests/cycle_settings_0031.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.96,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 23,
+  "take_profit_percent": 1.04,
+  "buyback_percent": 0.84,
+  "safety_offset": 0.3,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.81,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0032.json
+++ b/config/chatbot/tests/cycle_settings_0032.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.28,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 29,
+  "take_profit_percent": 1.0,
+  "buyback_percent": 0.59,
+  "safety_offset": 0.22,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.91,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0033.json
+++ b/config/chatbot/tests/cycle_settings_0033.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.5,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 23,
+  "take_profit_percent": 0.81,
+  "buyback_percent": 0.93,
+  "safety_offset": 0.36,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.54,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0034.json
+++ b/config/chatbot/tests/cycle_settings_0034.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.45,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 11,
+  "take_profit_percent": 1.64,
+  "buyback_percent": 0.56,
+  "safety_offset": 0.41,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.45,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0035.json
+++ b/config/chatbot/tests/cycle_settings_0035.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.31,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 12,
+  "take_profit_percent": 1.94,
+  "buyback_percent": 0.52,
+  "safety_offset": 0.43,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.87,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0036.json
+++ b/config/chatbot/tests/cycle_settings_0036.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.24,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 22,
+  "take_profit_percent": 1.91,
+  "buyback_percent": 0.64,
+  "safety_offset": 0.38,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.04,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0037.json
+++ b/config/chatbot/tests/cycle_settings_0037.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.67,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 11,
+  "take_profit_percent": 0.97,
+  "buyback_percent": 0.37,
+  "safety_offset": 0.48,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.6,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0038.json
+++ b/config/chatbot/tests/cycle_settings_0038.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.35,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 28,
+  "take_profit_percent": 0.73,
+  "buyback_percent": 0.6,
+  "safety_offset": 0.16,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.53,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0039.json
+++ b/config/chatbot/tests/cycle_settings_0039.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "SOL-EUR",
+  "pair": "SOLEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.99,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 17,
+  "take_profit_percent": 1.0,
+  "buyback_percent": 0.54,
+  "safety_offset": 0.27,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.8,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0040.json
+++ b/config/chatbot/tests/cycle_settings_0040.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.79,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 29,
+  "take_profit_percent": 1.25,
+  "buyback_percent": 0.98,
+  "safety_offset": 0.14,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.51,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0041.json
+++ b/config/chatbot/tests/cycle_settings_0041.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.32,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 13,
+  "take_profit_percent": 1.24,
+  "buyback_percent": 0.72,
+  "safety_offset": 0.44,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.6,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0042.json
+++ b/config/chatbot/tests/cycle_settings_0042.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.3,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 12,
+  "take_profit_percent": 1.1,
+  "buyback_percent": 0.83,
+  "safety_offset": 0.44,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.62,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0043.json
+++ b/config/chatbot/tests/cycle_settings_0043.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.73,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 10,
+  "take_profit_percent": 0.99,
+  "buyback_percent": 0.52,
+  "safety_offset": 0.14,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.45,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0044.json
+++ b/config/chatbot/tests/cycle_settings_0044.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.65,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 16,
+  "take_profit_percent": 0.52,
+  "buyback_percent": 0.43,
+  "safety_offset": 0.38,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.78,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0045.json
+++ b/config/chatbot/tests/cycle_settings_0045.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.69,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 15,
+  "take_profit_percent": 0.88,
+  "buyback_percent": 0.56,
+  "safety_offset": 0.49,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.1,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0046.json
+++ b/config/chatbot/tests/cycle_settings_0046.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.36,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 12,
+  "take_profit_percent": 1.13,
+  "buyback_percent": 0.85,
+  "safety_offset": 0.43,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 1.99,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0047.json
+++ b/config/chatbot/tests/cycle_settings_0047.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.72,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 10,
+  "take_profit_percent": 1.91,
+  "buyback_percent": 0.67,
+  "safety_offset": 0.14,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.81,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0048.json
+++ b/config/chatbot/tests/cycle_settings_0048.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.36,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 21,
+  "take_profit_percent": 1.35,
+  "buyback_percent": 0.73,
+  "safety_offset": 0.35,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.21,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0049.json
+++ b/config/chatbot/tests/cycle_settings_0049.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.91,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 25,
+  "take_profit_percent": 1.82,
+  "buyback_percent": 0.37,
+  "safety_offset": 0.39,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.0,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0050.json
+++ b/config/chatbot/tests/cycle_settings_0050.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.7,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 20,
+  "take_profit_percent": 0.92,
+  "buyback_percent": 0.98,
+  "safety_offset": 0.32,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.56,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0051.json
+++ b/config/chatbot/tests/cycle_settings_0051.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.72,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 12,
+  "take_profit_percent": 1.11,
+  "buyback_percent": 0.36,
+  "safety_offset": 0.14,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.05,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0052.json
+++ b/config/chatbot/tests/cycle_settings_0052.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.91,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 25,
+  "take_profit_percent": 0.72,
+  "buyback_percent": 0.72,
+  "safety_offset": 0.17,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.83,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0053.json
+++ b/config/chatbot/tests/cycle_settings_0053.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.2,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 15,
+  "take_profit_percent": 1.09,
+  "buyback_percent": 0.61,
+  "safety_offset": 0.44,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.64,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0054.json
+++ b/config/chatbot/tests/cycle_settings_0054.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.34,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 15,
+  "take_profit_percent": 0.83,
+  "buyback_percent": 0.63,
+  "safety_offset": 0.35,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.64,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0055.json
+++ b/config/chatbot/tests/cycle_settings_0055.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.89,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 29,
+  "take_profit_percent": 0.9,
+  "buyback_percent": 0.68,
+  "safety_offset": 0.1,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.33,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0056.json
+++ b/config/chatbot/tests/cycle_settings_0056.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.42,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 28,
+  "take_profit_percent": 1.5,
+  "buyback_percent": 0.78,
+  "safety_offset": 0.36,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.53,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0057.json
+++ b/config/chatbot/tests/cycle_settings_0057.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.23,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 13,
+  "take_profit_percent": 1.43,
+  "buyback_percent": 0.53,
+  "safety_offset": 0.28,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.24,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0058.json
+++ b/config/chatbot/tests/cycle_settings_0058.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.55,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 25,
+  "take_profit_percent": 1.23,
+  "buyback_percent": 0.84,
+  "safety_offset": 0.25,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 1.68,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0059.json
+++ b/config/chatbot/tests/cycle_settings_0059.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "LINK-EUR",
+  "pair": "LINKEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 1.0,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 28,
+  "take_profit_percent": 1.97,
+  "buyback_percent": 0.44,
+  "safety_offset": 0.4,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.96,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0060.json
+++ b/config/chatbot/tests/cycle_settings_0060.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.59,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 30,
+  "take_profit_percent": 1.04,
+  "buyback_percent": 0.46,
+  "safety_offset": 0.33,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.59,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0061.json
+++ b/config/chatbot/tests/cycle_settings_0061.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.5,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 26,
+  "take_profit_percent": 1.99,
+  "buyback_percent": 0.64,
+  "safety_offset": 0.41,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.11,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0062.json
+++ b/config/chatbot/tests/cycle_settings_0062.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.92,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 29,
+  "take_profit_percent": 0.5,
+  "buyback_percent": 0.33,
+  "safety_offset": 0.42,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.77,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0063.json
+++ b/config/chatbot/tests/cycle_settings_0063.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.25,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 21,
+  "take_profit_percent": 1.06,
+  "buyback_percent": 0.86,
+  "safety_offset": 0.45,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 1.6,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0064.json
+++ b/config/chatbot/tests/cycle_settings_0064.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.94,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 21,
+  "take_profit_percent": 0.65,
+  "buyback_percent": 0.32,
+  "safety_offset": 0.31,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.03,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0065.json
+++ b/config/chatbot/tests/cycle_settings_0065.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.97,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 19,
+  "take_profit_percent": 0.74,
+  "buyback_percent": 0.81,
+  "safety_offset": 0.45,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.07,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0066.json
+++ b/config/chatbot/tests/cycle_settings_0066.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.71,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 29,
+  "take_profit_percent": 1.65,
+  "buyback_percent": 0.47,
+  "safety_offset": 0.31,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.36,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0067.json
+++ b/config/chatbot/tests/cycle_settings_0067.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.79,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 19,
+  "take_profit_percent": 1.29,
+  "buyback_percent": 0.61,
+  "safety_offset": 0.16,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.11,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0068.json
+++ b/config/chatbot/tests/cycle_settings_0068.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.25,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 10,
+  "take_profit_percent": 0.68,
+  "buyback_percent": 0.32,
+  "safety_offset": 0.22,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.64,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0069.json
+++ b/config/chatbot/tests/cycle_settings_0069.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.76,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 24,
+  "take_profit_percent": 1.97,
+  "buyback_percent": 0.65,
+  "safety_offset": 0.3,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.15,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0070.json
+++ b/config/chatbot/tests/cycle_settings_0070.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.84,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 12,
+  "take_profit_percent": 1.95,
+  "buyback_percent": 0.67,
+  "safety_offset": 0.46,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.64,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0071.json
+++ b/config/chatbot/tests/cycle_settings_0071.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.59,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 15,
+  "take_profit_percent": 0.8,
+  "buyback_percent": 0.48,
+  "safety_offset": 0.37,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.22,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0072.json
+++ b/config/chatbot/tests/cycle_settings_0072.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.64,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 21,
+  "take_profit_percent": 1.44,
+  "buyback_percent": 0.95,
+  "safety_offset": 0.32,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.47,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0073.json
+++ b/config/chatbot/tests/cycle_settings_0073.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.21,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 18,
+  "take_profit_percent": 1.92,
+  "buyback_percent": 0.71,
+  "safety_offset": 0.21,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 1.71,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0074.json
+++ b/config/chatbot/tests/cycle_settings_0074.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.43,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 28,
+  "take_profit_percent": 1.59,
+  "buyback_percent": 0.88,
+  "safety_offset": 0.47,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.86,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0075.json
+++ b/config/chatbot/tests/cycle_settings_0075.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.72,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 26,
+  "take_profit_percent": 1.15,
+  "buyback_percent": 0.35,
+  "safety_offset": 0.13,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.65,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0076.json
+++ b/config/chatbot/tests/cycle_settings_0076.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.91,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 20,
+  "take_profit_percent": 0.95,
+  "buyback_percent": 0.73,
+  "safety_offset": 0.42,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.55,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0077.json
+++ b/config/chatbot/tests/cycle_settings_0077.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.28,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 10,
+  "take_profit_percent": 1.1,
+  "buyback_percent": 0.74,
+  "safety_offset": 0.18,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.05,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0078.json
+++ b/config/chatbot/tests/cycle_settings_0078.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.82,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 27,
+  "take_profit_percent": 1.02,
+  "buyback_percent": 0.38,
+  "safety_offset": 0.23,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.59,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0079.json
+++ b/config/chatbot/tests/cycle_settings_0079.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ETH-EUR",
+  "pair": "ETHEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.69,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 23,
+  "take_profit_percent": 1.36,
+  "buyback_percent": 0.32,
+  "safety_offset": 0.17,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.36,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0080.json
+++ b/config/chatbot/tests/cycle_settings_0080.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.31,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 25,
+  "take_profit_percent": 0.72,
+  "buyback_percent": 0.62,
+  "safety_offset": 0.22,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.6,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0081.json
+++ b/config/chatbot/tests/cycle_settings_0081.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.68,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 27,
+  "take_profit_percent": 1.66,
+  "buyback_percent": 0.63,
+  "safety_offset": 0.49,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.67,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0082.json
+++ b/config/chatbot/tests/cycle_settings_0082.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.22,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 18,
+  "take_profit_percent": 1.13,
+  "buyback_percent": 0.94,
+  "safety_offset": 0.14,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.96,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0083.json
+++ b/config/chatbot/tests/cycle_settings_0083.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.87,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 28,
+  "take_profit_percent": 1.74,
+  "buyback_percent": 0.74,
+  "safety_offset": 0.24,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.67,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0084.json
+++ b/config/chatbot/tests/cycle_settings_0084.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.34,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 22,
+  "take_profit_percent": 0.83,
+  "buyback_percent": 0.4,
+  "safety_offset": 0.25,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.86,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0085.json
+++ b/config/chatbot/tests/cycle_settings_0085.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.54,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 10,
+  "take_profit_percent": 1.28,
+  "buyback_percent": 0.51,
+  "safety_offset": 0.39,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.39,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0086.json
+++ b/config/chatbot/tests/cycle_settings_0086.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.49,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 17,
+  "take_profit_percent": 1.58,
+  "buyback_percent": 0.41,
+  "safety_offset": 0.19,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 1.98,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0087.json
+++ b/config/chatbot/tests/cycle_settings_0087.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.33,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 23,
+  "take_profit_percent": 1.04,
+  "buyback_percent": 0.87,
+  "safety_offset": 0.32,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.95,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0088.json
+++ b/config/chatbot/tests/cycle_settings_0088.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.87,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 14,
+  "take_profit_percent": 1.91,
+  "buyback_percent": 0.48,
+  "safety_offset": 0.16,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.0,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0089.json
+++ b/config/chatbot/tests/cycle_settings_0089.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.97,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 29,
+  "take_profit_percent": 1.34,
+  "buyback_percent": 0.82,
+  "safety_offset": 0.38,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.23,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0090.json
+++ b/config/chatbot/tests/cycle_settings_0090.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.21,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 27,
+  "take_profit_percent": 1.79,
+  "buyback_percent": 0.84,
+  "safety_offset": 0.31,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.92,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0091.json
+++ b/config/chatbot/tests/cycle_settings_0091.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.78,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 22,
+  "take_profit_percent": 0.65,
+  "buyback_percent": 0.74,
+  "safety_offset": 0.2,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.78,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0092.json
+++ b/config/chatbot/tests/cycle_settings_0092.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.62,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 25,
+  "take_profit_percent": 0.77,
+  "buyback_percent": 0.95,
+  "safety_offset": 0.37,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.28,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0093.json
+++ b/config/chatbot/tests/cycle_settings_0093.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.66,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 19,
+  "take_profit_percent": 1.54,
+  "buyback_percent": 0.69,
+  "safety_offset": 0.3,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.44,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0094.json
+++ b/config/chatbot/tests/cycle_settings_0094.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.58,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 15,
+  "take_profit_percent": 1.55,
+  "buyback_percent": 0.5,
+  "safety_offset": 0.11,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.19,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0095.json
+++ b/config/chatbot/tests/cycle_settings_0095.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.35,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 17,
+  "take_profit_percent": 1.53,
+  "buyback_percent": 0.47,
+  "safety_offset": 0.43,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.49,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0096.json
+++ b/config/chatbot/tests/cycle_settings_0096.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.75,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 13,
+  "take_profit_percent": 0.79,
+  "buyback_percent": 0.94,
+  "safety_offset": 0.41,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 1.71,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0097.json
+++ b/config/chatbot/tests/cycle_settings_0097.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.98,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 18,
+  "take_profit_percent": 1.02,
+  "buyback_percent": 0.53,
+  "safety_offset": 0.34,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.95,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0098.json
+++ b/config/chatbot/tests/cycle_settings_0098.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.25,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 19,
+  "take_profit_percent": 1.72,
+  "buyback_percent": 0.99,
+  "safety_offset": 0.28,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 1.81,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0099.json
+++ b/config/chatbot/tests/cycle_settings_0099.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "XRP-EUR",
+  "pair": "XRPEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.28,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 27,
+  "take_profit_percent": 1.26,
+  "buyback_percent": 0.45,
+  "safety_offset": 0.48,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.66,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0100.json
+++ b/config/chatbot/tests/cycle_settings_0100.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.62,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 10,
+  "take_profit_percent": 1.13,
+  "buyback_percent": 0.95,
+  "safety_offset": 0.32,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.43,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0101.json
+++ b/config/chatbot/tests/cycle_settings_0101.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.46,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 24,
+  "take_profit_percent": 1.19,
+  "buyback_percent": 0.57,
+  "safety_offset": 0.25,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.43,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0102.json
+++ b/config/chatbot/tests/cycle_settings_0102.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.8,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 20,
+  "take_profit_percent": 0.67,
+  "buyback_percent": 0.7,
+  "safety_offset": 0.5,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.81,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0103.json
+++ b/config/chatbot/tests/cycle_settings_0103.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.61,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 30,
+  "take_profit_percent": 1.43,
+  "buyback_percent": 0.36,
+  "safety_offset": 0.24,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 1.85,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0104.json
+++ b/config/chatbot/tests/cycle_settings_0104.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.6,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 18,
+  "take_profit_percent": 1.64,
+  "buyback_percent": 0.4,
+  "safety_offset": 0.26,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.79,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0105.json
+++ b/config/chatbot/tests/cycle_settings_0105.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.99,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 24,
+  "take_profit_percent": 1.86,
+  "buyback_percent": 0.54,
+  "safety_offset": 0.46,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.46,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0106.json
+++ b/config/chatbot/tests/cycle_settings_0106.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.43,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 11,
+  "take_profit_percent": 1.67,
+  "buyback_percent": 0.78,
+  "safety_offset": 0.44,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.21,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0107.json
+++ b/config/chatbot/tests/cycle_settings_0107.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.6,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 27,
+  "take_profit_percent": 1.56,
+  "buyback_percent": 0.34,
+  "safety_offset": 0.19,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.54,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0108.json
+++ b/config/chatbot/tests/cycle_settings_0108.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.87,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 17,
+  "take_profit_percent": 1.57,
+  "buyback_percent": 0.73,
+  "safety_offset": 0.26,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.32,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0109.json
+++ b/config/chatbot/tests/cycle_settings_0109.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.31,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 26,
+  "take_profit_percent": 1.61,
+  "buyback_percent": 0.77,
+  "safety_offset": 0.19,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 2.75,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0110.json
+++ b/config/chatbot/tests/cycle_settings_0110.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.45,
+  "initial_portfolio_eur": 1500,
+  "reinvestment_percent": 30,
+  "take_profit_percent": 1.07,
+  "buyback_percent": 0.83,
+  "safety_offset": 0.27,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.84,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0111.json
+++ b/config/chatbot/tests/cycle_settings_0111.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 2,
+  "startbuy_threshold": 0.5,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 12,
+  "take_profit_percent": 1.78,
+  "buyback_percent": 0.44,
+  "safety_offset": 0.22,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.59,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0112.json
+++ b/config/chatbot/tests/cycle_settings_0112.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.55,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 16,
+  "take_profit_percent": 1.22,
+  "buyback_percent": 0.33,
+  "safety_offset": 0.36,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 1.54,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0113.json
+++ b/config/chatbot/tests/cycle_settings_0113.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.4,
+  "initial_portfolio_eur": 2000,
+  "reinvestment_percent": 13,
+  "take_profit_percent": 0.89,
+  "buyback_percent": 0.94,
+  "safety_offset": 0.11,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 3.28,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0114.json
+++ b/config/chatbot/tests/cycle_settings_0114.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.71,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 18,
+  "take_profit_percent": 1.06,
+  "buyback_percent": 0.57,
+  "safety_offset": 0.25,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.15,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": false
+}

--- a/config/chatbot/tests/cycle_settings_0115.json
+++ b/config/chatbot/tests/cycle_settings_0115.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 4,
+  "startbuy_threshold": 0.93,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 30,
+  "take_profit_percent": 1.51,
+  "buyback_percent": 0.46,
+  "safety_offset": 0.42,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 3.26,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0116.json
+++ b/config/chatbot/tests/cycle_settings_0116.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.44,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 11,
+  "take_profit_percent": 1.78,
+  "buyback_percent": 0.9,
+  "safety_offset": 0.31,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 4.11,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0117.json
+++ b/config/chatbot/tests/cycle_settings_0117.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 1,
+  "startbuy_threshold": 0.69,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 19,
+  "take_profit_percent": 1.34,
+  "buyback_percent": 0.68,
+  "safety_offset": 0.29,
+  "enable_stop_loss": false,
+  "stop_loss_percent": 2.58,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0118.json
+++ b/config/chatbot/tests/cycle_settings_0118.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 3,
+  "startbuy_threshold": 0.7,
+  "initial_portfolio_eur": 1000,
+  "reinvestment_percent": 17,
+  "take_profit_percent": 1.6,
+  "buyback_percent": 0.75,
+  "safety_offset": 0.13,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 4.89,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/config/chatbot/tests/cycle_settings_0119.json
+++ b/config/chatbot/tests/cycle_settings_0119.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "ADA-EUR",
+  "pair": "ADAEUR",
+  "use_kraken_price": false,
+  "refresh_rate": 5,
+  "startbuy_threshold": 0.88,
+  "initial_portfolio_eur": 500,
+  "reinvestment_percent": 22,
+  "take_profit_percent": 1.67,
+  "buyback_percent": 0.72,
+  "safety_offset": 0.27,
+  "enable_stop_loss": true,
+  "stop_loss_percent": 1.65,
+  "debug": false,
+  "log_interval_terminal": 1,
+  "log_interval_file": 1,
+  "auto_log": true
+}

--- a/docs/elliott_wave_bot.md
+++ b/docs/elliott_wave_bot.md
@@ -13,7 +13,7 @@ Copy `config/chatbot/elliott_wave_settings.json.example` to
 
 ```json
 {
-    "symbol": "BTC-USD",
+    "symbol": "BTC-EUR",
     "period": "1y",
     "interval": "1d",
     "profit_pct": 2.0,

--- a/docs/limit_cycle_bot.md
+++ b/docs/limit_cycle_bot.md
@@ -8,7 +8,7 @@ Copy `config/chatbot/limit_cycle_settings.json.example` to `config/chatbot/limit
 
 ```json
 {
-    "symbol": "BTC-USD",
+    "symbol": "BTC-EUR",
     "pair": "XBTEUR",
     "use_kraken_price": false,
     "refresh_rate": 2,

--- a/docs/live_trader_bot.md
+++ b/docs/live_trader_bot.md
@@ -8,7 +8,7 @@ Kopiere `config/chatbot/live_trader_settings.json.example` nach `config/chatbot/
 
 ```json
 {
-    "symbol": "BTC-USD",
+    "symbol": "BTC-EUR",
     "lookback_days": 30,
     "interval": "1h",
     "trade_amount": 1000,
@@ -23,7 +23,7 @@ Kopiere `config/chatbot/live_trader_settings.json.example` nach `config/chatbot/
 
 ### Felder
 
-- **symbol** – Ticker‑Symbol für Yahoo Finance (z. B. `BTC-USD`).
+- **symbol** – Ticker‑Symbol für Yahoo Finance (z. B. `BTC-EUR`).
 - **lookback_days** – Wie viele Tage an Historie beim Abruf verwendet werden.
 - **interval** – Zeitintervall der historischen Daten (`1h`, `1d` …).
 - **trade_amount** – Virtuelles Startkapital, das beim ersten Kaufsignal eingesetzt wird.

--- a/modules/chatbot/chatbot.py
+++ b/modules/chatbot/chatbot.py
@@ -13,6 +13,8 @@ def run() -> None:
     print("2. Run Elliott wave bot")
     print("3. Run live trader bot")
     print("4. Run limit cycle bot")
+    print("5. Run cycle bot tests")
+    print("6. Evaluate cycle bot logs")
     print("99. Back")
     choice = input("Option: ") or "99"
     if choice == "1":
@@ -50,5 +52,14 @@ def run() -> None:
         settings = CycleSettings.load(filename)
         bot = LimitCycleBot(settings)
         bot.run()
+    elif choice == "5":
+        from .test_runner import run_cycle_tests
+
+        run_cycle_tests()
+    elif choice == "6":
+        from .evaluate_cycle_logs import find_best
+
+        num = input("Number of results (default 5): ") or "5"
+        find_best(int(num))
 
 

--- a/modules/chatbot/elliott_wave_bot.py
+++ b/modules/chatbot/elliott_wave_bot.py
@@ -21,7 +21,7 @@ class Trade:
 
 @dataclass
 class Settings:
-    symbol: str = "BTC-USD"  # Yahoo symbol
+    symbol: str = "BTC-EUR"  # Yahoo symbol
     period: str = "1y"  # historical data period
     interval: str = "1d"  # data interval
     profit_pct: float = 2.0  # profit target per trade

--- a/modules/chatbot/evaluate_cycle_logs.py
+++ b/modules/chatbot/evaluate_cycle_logs.py
@@ -1,0 +1,40 @@
+import glob
+import json
+import os
+import re
+from typing import List, Tuple
+
+LOG_PATTERN = os.path.join("log", "limit_cycle_*.log")
+
+RESULT_RE = re.compile(r"Gesamtgewinn: ([+-]?[0-9\.]+)")
+
+
+def parse_log(path: str) -> Tuple[float, dict]:
+    with open(path, "r") as fh:
+        content = fh.read()
+    match = RESULT_RE.search(content)
+    profit = float(match.group(1)) if match else 0.0
+    settings = {}
+    if "Settings:" in content:
+        try:
+            settings_json = content.split("Settings:\n", 1)[1].split("\n\n", 1)[0]
+            settings = json.loads(settings_json)
+        except Exception:
+            pass
+    return profit, settings
+
+
+def find_best(top_n: int = 5) -> None:
+    results: List[Tuple[float, str, dict]] = []
+    for path in glob.glob(LOG_PATTERN):
+        profit, settings = parse_log(path)
+        results.append((profit, path, settings))
+    results.sort(key=lambda x: x[0], reverse=True)
+    for profit, path, settings in results[:top_n]:
+        print(f"{path}: {profit:.2f} €")
+        print(json.dumps(settings, indent=2))
+        print()
+
+
+if __name__ == "__main__":
+    find_best()

--- a/modules/chatbot/generate_cycle_tests.py
+++ b/modules/chatbot/generate_cycle_tests.py
@@ -1,0 +1,73 @@
+import json
+import os
+import random
+
+PAIRS = [
+    "XBTEUR",  # Bitcoin
+    "SOLEUR",  # Solana
+    "LINKEUR",  # Chainlink
+    "ETHEUR",  # Ethereum
+    "XRPEUR",  # Ripple
+    "ADAEUR",  # Cardano
+]
+
+SYMBOL_MAP = {
+    "XBTEUR": "BTC-EUR",
+    "SOLEUR": "SOL-EUR",
+    "LINKEUR": "LINK-EUR",
+    "ETHEUR": "ETH-EUR",
+    "XRPEUR": "XRP-EUR",
+    "ADAEUR": "ADA-EUR",
+}
+
+BASE_SETTINGS = {
+    "symbol": "BTC-EUR",
+    "pair": "XBTEUR",
+    "use_kraken_price": False,
+    "refresh_rate": 2,
+    "startbuy_threshold": 0.4,
+    "initial_portfolio_eur": 1000,
+    "reinvestment_percent": 15,
+    "take_profit_percent": 0.8,
+    "buyback_percent": 0.5,
+    "safety_offset": 0.15,
+    "enable_stop_loss": False,
+    "stop_loss_percent": 2.0,
+    "debug": False,
+    "log_interval_terminal": 1,
+    "log_interval_file": 1,
+    "auto_log": True,
+}
+
+def random_setting(pair: str) -> dict:
+    s = BASE_SETTINGS.copy()
+    s["pair"] = pair
+    s["symbol"] = SYMBOL_MAP.get(pair, "BTC-EUR")
+    s["refresh_rate"] = random.randint(1, 5)
+    s["startbuy_threshold"] = round(random.uniform(0.2, 1.0), 2)
+    s["initial_portfolio_eur"] = random.choice([500, 1000, 1500, 2000])
+    s["reinvestment_percent"] = random.randint(10, 30)
+    s["take_profit_percent"] = round(random.uniform(0.5, 2.0), 2)
+    s["buyback_percent"] = round(random.uniform(0.3, 1.0), 2)
+    s["safety_offset"] = round(random.uniform(0.1, 0.5), 2)
+    s["enable_stop_loss"] = random.choice([True, False])
+    s["stop_loss_percent"] = round(random.uniform(1.5, 5.0), 2)
+    s["auto_log"] = random.choice([True, False])
+    return s
+
+def main(count_per_pair: int = 20) -> None:
+    """Generate settings for each pair in :data:`PAIRS`."""
+    out_dir = os.path.join("config", "chatbot", "tests")
+    os.makedirs(out_dir, exist_ok=True)
+    total = 0
+    for pair in PAIRS:
+        for i in range(count_per_pair):
+            cfg = random_setting(pair)
+            path = os.path.join(out_dir, f"cycle_settings_{total:04d}.json")
+            with open(path, "w") as fh:
+                json.dump(cfg, fh, indent=2)
+            total += 1
+    print(f"Generated {total} test configs in {out_dir}")
+
+if __name__ == "__main__":
+    main()

--- a/modules/chatbot/limit_cycle_bot.py
+++ b/modules/chatbot/limit_cycle_bot.py
@@ -15,7 +15,7 @@ import lib.lib as lib
 
 @dataclass
 class CycleSettings:
-    symbol: str = "BTC-USD"  # Yahoo Finance symbol
+    symbol: str = "BTC-EUR"  # Yahoo Finance symbol
     pair: str = "XBTEUR"  # Kraken trading pair
     use_kraken_price: bool = False  # fetch price from Kraken instead of Yahoo
     refresh_rate: int = 2  # seconds between price checks
@@ -343,8 +343,8 @@ class LimitCycleBot(BaseChatBot):
                     self.open_stop_loss = LimitOrder("sell", stop_price, amount)
 
     # --- Main loop -------------------------------------------------------
-    def run(self) -> None:
-        """Run the trading loop until interrupted."""
+    def run(self, max_iterations: int | None = None) -> None:
+        """Run the trading loop until interrupted or ``max_iterations`` reached."""
         os.makedirs("log", exist_ok=True)
         self.log_file_path = os.path.join(
             "log", f"limit_cycle_{int(self.start_time)}.log"
@@ -355,6 +355,7 @@ class LimitCycleBot(BaseChatBot):
             fh.write("\n\n")
 
         reason = "completed"
+        iterations = 0
         try:
             price = self._get_price()
             if price is None:
@@ -376,6 +377,10 @@ class LimitCycleBot(BaseChatBot):
                 if self.log_counter % self.settings.log_interval_file == 0:
                     self._log(price, to_terminal=False, to_file=True)
                 time.sleep(self.settings.refresh_rate)
+                iterations += 1
+                if max_iterations is not None and iterations >= max_iterations:
+                    reason = "max iterations reached"
+                    break
         except KeyboardInterrupt:
             reason = "aborted by user"
         except Exception as exc:

--- a/modules/chatbot/live_trader_bot.py
+++ b/modules/chatbot/live_trader_bot.py
@@ -16,7 +16,7 @@ import yfinance as yf
 class LiveSettings:
     """Configuration for :class:`LiveTraderBot`."""
 
-    symbol: str = "BTC-USD"  # ticker symbol
+    symbol: str = "BTC-EUR"  # ticker symbol
     lookback_days: int = 30  # days of data to analyse
     interval: str = "1h"  # data granularity
     trade_amount: float = 1000.0  # amount used per trade

--- a/modules/chatbot/test_runner.py
+++ b/modules/chatbot/test_runner.py
@@ -1,0 +1,18 @@
+import glob
+import os
+from .limit_cycle_bot import LimitCycleBot, CycleSettings
+
+
+def run_cycle_tests(max_iterations: int = 10) -> None:
+    """Run LimitCycleBot with all test settings sequentially."""
+    settings_dir = os.path.join("config", "chatbot", "tests")
+    files = sorted(glob.glob(os.path.join(settings_dir, "*.json")))
+    if not files:
+        print(f"No test configs found in {settings_dir}")
+        return
+    print(f"Running {len(files)} cycle bot tests...")
+    for fname in files:
+        print(f"\nRunning {os.path.basename(fname)}")
+        settings = CycleSettings.load(fname)
+        bot = LimitCycleBot(settings)
+        bot.run(max_iterations=max_iterations)


### PR DESCRIPTION
## Summary
- use EUR-based Yahoo Finance symbols in generator and bots
- update example configs and docs to show BTC-EUR
- regenerate test settings with EUR symbols

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_685c59e22044832ab7e772513b42da09