### PR TITLE
Enable parallel test runs with custom log directory

### DIFF
--- a/modules/chatbot/limit_cycle_bot.py
+++ b/modules/chatbot/limit_cycle_bot.py
@@ -343,11 +343,11 @@ class LimitCycleBot(BaseChatBot):
                     self.open_stop_loss = LimitOrder("sell", stop_price, amount)
 
     # --- Main loop -------------------------------------------------------
-    def run(self, max_iterations: int | None = None) -> None:
+    def run(self, max_iterations: int | None = None, *, log_dir: str = "log") -> None:
         """Run the trading loop until interrupted or ``max_iterations`` reached."""
-        os.makedirs("log", exist_ok=True)
+        os.makedirs(log_dir, exist_ok=True)
         self.log_file_path = os.path.join(
-            "log", f"limit_cycle_{int(self.start_time)}.log"
+            log_dir, f"limit_cycle_{int(self.start_time)}.log"
         )
         with open(self.log_file_path, "w") as fh:
             fh.write("Settings:\n")

--- a/modules/chatbot/test_runner.py
+++ b/modules/chatbot/test_runner.py
@@ -1,18 +1,30 @@
 import glob
 import os
+import threading
 from .limit_cycle_bot import LimitCycleBot, CycleSettings
 
 
-def run_cycle_tests(max_iterations: int = 10) -> None:
-    """Run LimitCycleBot with all test settings sequentially."""
+def run_cycle_tests(max_iterations: int | None = 10, *, log_dir: str = os.path.join("log", "test")) -> None:
+    """Run LimitCycleBot with all test settings in parallel."""
     settings_dir = os.path.join("config", "chatbot", "tests")
     files = sorted(glob.glob(os.path.join(settings_dir, "*.json")))
     if not files:
         print(f"No test configs found in {settings_dir}")
         return
-    print(f"Running {len(files)} cycle bot tests...")
+    os.makedirs(log_dir, exist_ok=True)
+    print(f"Running {len(files)} cycle bot tests in parallel...")
+    threads = []
     for fname in files:
-        print(f"\nRunning {os.path.basename(fname)}")
+        print(f"\nStarting {os.path.basename(fname)}")
         settings = CycleSettings.load(fname)
         bot = LimitCycleBot(settings)
-        bot.run(max_iterations=max_iterations)
+        t = threading.Thread(
+            target=bot.run,
+            kwargs={"max_iterations": max_iterations, "log_dir": log_dir},
+            daemon=True,
+        )
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()


### PR DESCRIPTION
## Summary
- run LimitCycleBot tests concurrently
- allow specifying a custom log directory when running bots

## Testing
- `python -m py_compile modules/chatbot/test_runner.py modules/chatbot/limit_cycle_bot.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_685c6e25db30832a9e015b1e29f34709