### PR TITLE
Use Kraken data everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ menu interface. A few examples are:
 - **kraken_request** – make individual API requests
 - **telegram_bot** – minimal read-only Telegram bot
 - **generate-trades-history-csv** – export trade history into CSV format
-- **chatbot** – run small strategy bots fetching data from Kraken and Yahoo Finance
+- **chatbot** – run small strategy bots fetching data from Kraken
 
 ### Output Folder
 
@@ -97,7 +97,7 @@ added.
 ## Chatbots
 
 The `chatbot` module contains small strategy bots. An example `TickerBot`
-fetches price data from both Kraken and Yahoo Finance and prints the values.
+fetches price data from Kraken and prints the values.
 Another demo called `ElliottWaveBot` performs a very rough Elliott wave
 analysis on historical prices and simulates trades based on configurable
 criteria.

--- a/config/chatbot/elliott_wave_settings.json.example
+++ b/config/chatbot/elliott_wave_settings.json.example
@@ -1,7 +1,7 @@
 {
-    "symbol": "BTC-EUR",
-    "period": "1y",
-    "interval": "1d",
+    "pair": "XBTEUR",
+    "lookback_days": 365,
+    "interval": 1440,
     "profit_pct": 2.0,
     "start_balance": 1000,
     "wave_threshold_pct": 2.5

--- a/config/chatbot/limit_cycle_settings.json.example
+++ b/config/chatbot/limit_cycle_settings.json.example
@@ -1,7 +1,5 @@
 {
-    "symbol": "BTC-EUR",
     "pair": "XBTEUR",
-    "use_kraken_price": false,
     "refresh_rate": 2,
     "startbuy_threshold": 0.4,
     "initial_portfolio_eur": 1000,

--- a/config/chatbot/live_trader_settings.json.example
+++ b/config/chatbot/live_trader_settings.json.example
@@ -1,7 +1,7 @@
 {
-    "symbol": "BTC-EUR",
+    "pair": "XBTEUR",
     "lookback_days": 30,
-    "interval": "1h",
+    "interval": 60,
     "trade_amount": 1000,
     "profit_target_pct": 1.5,
     "check_interval": 30,

--- a/docs/elliott_wave_bot.md
+++ b/docs/elliott_wave_bot.md
@@ -13,9 +13,9 @@ Copy `config/chatbot/elliott_wave_settings.json.example` to
 
 ```json
 {
-    "symbol": "BTC-EUR",
-    "period": "1y",
-    "interval": "1d",
+    "pair": "XBTEUR",
+    "lookback_days": 365,
+    "interval": 1440,
     "profit_pct": 2.0,
     "start_balance": 1000,
     "wave_threshold_pct": 2.5
@@ -24,8 +24,7 @@ Copy `config/chatbot/elliott_wave_settings.json.example` to
 
 ### Options
 
-- **symbol** – Ticker symbol used with Yahoo Finance. Determines which asset
-  prices are analysed.
+- **pair** – Kraken trading pair used to retrieve price data.
 - **period** – How far back the historical data should go (e.g. `1y` for one
   year or `6mo` for six months).
 - **interval** – Resolution of the price data (`1d`, `1h`, etc.). Shorter
@@ -40,16 +39,12 @@ Copy `config/chatbot/elliott_wave_settings.json.example` to
 
 ### Valid periods and intervals
 
-Historical data is requested via Yahoo Finance, which accepts specific strings
-for time ranges and resolutions:
+Historical data is requested via Kraken's OHLC endpoint, which accepts specific
+intervals:
 
-- **Periods**: `1d`, `5d`, `1mo`, `3mo`, `6mo`, `1y`, `2y`, `5y`, `10y`, `ytd`,
-  `max`
-- **Intervals**: `1m`, `2m`, `5m`, `15m`, `30m`, `60m`, `90m`, `1h`, `1d`, `5d`,
-  `1wk`, `1mo`, `3mo`
+- **Intervals**: `1`, `5`, `15`, `30`, `60`, `240`, `1440`, `10080`, `21600`
 
-Intraday intervals (`1m`–`1h`) are limited to roughly the last 60 days of
-history.
+Intraday intervals can be queried for roughly the last 60 days of history.
 
 Changing these values influences how many signals the bot will generate. For
 example, reducing `wave_threshold_pct` and `interval` leads to frequent trades

--- a/docs/limit_cycle_bot.md
+++ b/docs/limit_cycle_bot.md
@@ -29,9 +29,7 @@ Copy `config/chatbot/limit_cycle_settings.json.example` to `config/chatbot/limit
 
 -### Fields
 
-- **symbol** – Ticker symbol used for price retrieval via Yahoo Finance.
 - **pair** – Kraken trading pair used when fetching prices from the API.
-- **use_kraken_price** – If `true`, the bot retrieves the latest price from Kraken.
 - **refresh_rate** – Seconds between price checks.
 - **startbuy_threshold** – Percentage above the current price for the initial buy order.
 - **initial_portfolio_eur** – Euro amount used for the very first trade.

--- a/docs/live_trader_bot.md
+++ b/docs/live_trader_bot.md
@@ -1,6 +1,6 @@
 # LiveTraderBot
 
-`LiveTraderBot` ist ein einfacher Bot, der kontinuierlich Kursdaten aus Yahoo Finance auswertet und anhand einer Moving-Average-Strategie Kauf- und Verkaufszeitpunkte simuliert. Er verschickt dabei lediglich Handlungsempfehlungen und führt keine echten Trades aus. Im Gegensatz zum `ElliottWaveBot` stoppt dieser Bot nicht nach einer Simulation, sondern läuft dauerhaft weiter und aktualisiert seine Berechnungen regelmäßig. Aktivierst du Telegram, werden die Empfehlungen an dein Chatfenster gesendet.
+`LiveTraderBot` ist ein einfacher Bot, der kontinuierlich Kursdaten von Kraken auswertet und anhand einer Moving-Average-Strategie Kauf- und Verkaufszeitpunkte simuliert. Er verschickt dabei lediglich Handlungsempfehlungen und führt keine echten Trades aus. Im Gegensatz zum `ElliottWaveBot` stoppt dieser Bot nicht nach einer Simulation, sondern läuft dauerhaft weiter und aktualisiert seine Berechnungen regelmäßig. Aktivierst du Telegram, werden die Empfehlungen an dein Chatfenster gesendet.
 
 ## Konfiguration
 
@@ -8,9 +8,9 @@ Kopiere `config/chatbot/live_trader_settings.json.example` nach `config/chatbot/
 
 ```json
 {
-    "symbol": "BTC-EUR",
+    "pair": "XBTEUR",
     "lookback_days": 30,
-    "interval": "1h",
+    "interval": 60,
     "trade_amount": 1000,
     "profit_target_pct": 1.5,
     "check_interval": 30,
@@ -23,7 +23,7 @@ Kopiere `config/chatbot/live_trader_settings.json.example` nach `config/chatbot/
 
 ### Felder
 
-- **symbol** – Ticker‑Symbol für Yahoo Finance (z. B. `BTC-EUR`).
+- **pair** – Kraken-Handelspaar (z. B. `XBTEUR`).
 - **lookback_days** – Wie viele Tage an Historie beim Abruf verwendet werden.
 - **interval** – Zeitintervall der historischen Daten (`1h`, `1d` …).
 - **trade_amount** – Virtuelles Startkapital, das beim ersten Kaufsignal eingesetzt wird.
@@ -36,19 +36,13 @@ Kopiere `config/chatbot/live_trader_settings.json.example` nach `config/chatbot/
 
 ### Gültige Zeitangaben
 
-Die Daten stammen von Yahoo Finance. Für `interval` kannst du eine der
+Die Daten stammen vom Kraken-OHLC-Endpunkt. Für `interval` kannst du eine der
 folgenden Auflösungen angeben:
 
 - `1m`, `2m`, `5m`, `15m`, `30m`, `60m`, `90m`, `1h`, `1d`, `5d`, `1wk`,
   `1mo`, `3mo`
 
-`lookback_days` wird intern zu einem `period`-String im Format `Nd`
-umgewandelt. Anstelle einer Tageszahl wären auch die
-Standardperioden von Yahoo Finance möglich:
-`1d`, `5d`, `1mo`, `3mo`, `6mo`, `1y`, `2y`, `5y`, `10y`, `ytd`, `max`.
-
-Bei Intervallen unterhalb von `1d` liefert Yahoo Finance lediglich Daten
-der letzten ca. 60 Tage.
+`lookback_days` wird in einen Zeitstempel für die Abfrage umgerechnet.
 
 Der Parameter `slope_window_minutes` wertet nur Kursdaten in diesem Zeitfenster aus.
 Für aussagekräftige Prognosen sollte `interval` deutlich kleiner als dieser

--- a/lib/kraken_api.py
+++ b/lib/kraken_api.py
@@ -71,6 +71,14 @@ def ticker(pair: str = "XBTUSD") -> Dict:
     return public_request("Ticker", {"pair": pair})
 
 
+def ohlc(pair: str = "XBTUSD", interval: int = 1, since: int | None = None) -> Dict:
+    """Return OHLC data for a pair."""
+    params = {"pair": pair, "interval": interval}
+    if since is not None:
+        params["since"] = since
+    return public_request("OHLC", params)
+
+
 def get_open_orders(api_key: str, api_sec: str) -> Dict:
     return private_request("OpenOrders", {}, api_key, api_sec)
 

--- a/modules/chatbot/base.py
+++ b/modules/chatbot/base.py
@@ -1,8 +1,6 @@
 """Base classes and helpers for strategy chatbots."""
 
-from typing import Tuple
-
-import yfinance as yf
+import time
 
 from lib import kraken_api
 
@@ -10,40 +8,36 @@ from lib import kraken_api
 class BaseChatBot:
     """Base chatbot providing data fetching helpers."""
 
+    _last_call = 0.0
+    _rate_limit = 1.0  # seconds between public requests
+
     def fetch_kraken_ticker(self, pair: str = "XBTUSD") -> dict:
         """Return ticker info for a currency pair using Kraken public API."""
-        return kraken_api.ticker(pair)
-
-    def fetch_yahoo_price(self, symbol: str) -> float | None:
-        """Return the latest price for a symbol from Yahoo Finance."""
-        ticker = yf.Ticker(symbol)
-        data = ticker.history(period="1d", interval="1m")
-        if data.empty:
-            return None
-        return float(data["Close"].iloc[-1])
+        wait = self._rate_limit - (time.time() - self._last_call)
+        if wait > 0:
+            time.sleep(wait)
+        data = kraken_api.ticker(pair)
+        self._last_call = time.time()
+        return data
 
 
 class TickerBot(BaseChatBot):
-    """Simple bot that prints prices from Kraken and Yahoo Finance."""
+    """Simple bot that prints prices from Kraken."""
 
-    def __init__(self, pair: str = "XBTUSD", symbol: str = "AAPL", delay: int = 5):
+    def __init__(self, pair: str = "XBTUSD", delay: int = 1):
         self.pair = pair
-        self.symbol = symbol
-        self.delay = delay
+        self.delay = max(delay, self._rate_limit)
 
     def run(self) -> None:
         import time
 
-        print(
-            f"Starting TickerBot for Kraken pair {self.pair} and Yahoo symbol {self.symbol}"
-        )
+        print(f"Starting TickerBot for Kraken pair {self.pair}")
         for _ in range(3):
             kdata = self.fetch_kraken_ticker(self.pair)
             last = None
             if kdata.get("result"):
                 info = next(iter(kdata["result"].values()))
                 last = info.get("c", [None])[0]
-            yprice = self.fetch_yahoo_price(self.symbol)
-            print(f"Kraken last: {last}  Yahoo price: {yprice}")
+            print(f"Kraken last: {last}")
             time.sleep(self.delay)
 

--- a/modules/chatbot/elliott_wave_bot.py
+++ b/modules/chatbot/elliott_wave_bot.py
@@ -9,7 +9,7 @@ import json
 import os
 
 import pandas as pd
-import yfinance as yf
+from lib import kraken_api
 
 
 @dataclass
@@ -21,9 +21,9 @@ class Trade:
 
 @dataclass
 class Settings:
-    symbol: str = "BTC-EUR"  # Yahoo symbol
-    period: str = "1y"  # historical data period
-    interval: str = "1d"  # data interval
+    pair: str = "XBTEUR"  # Kraken trading pair
+    lookback_days: int = 365  # days of historical data
+    interval: int = 1440  # minutes between data points
     profit_pct: float = 2.0  # profit target per trade
     start_balance: float = 1000.0  # initial capital for simulation
     wave_threshold_pct: float = 2.5  # % move defining a wave
@@ -50,9 +50,15 @@ class ElliottWaveBot:
         self.trades: List[Trade] = []
 
     def fetch_data(self) -> pd.DataFrame:
-        ticker = yf.Ticker(self.settings.symbol)
-        df = ticker.history(period=self.settings.period, interval=self.settings.interval)
-        df = df.dropna()
+        since = int((pd.Timestamp.utcnow() - pd.Timedelta(days=self.settings.lookback_days)).timestamp())
+        resp = kraken_api.ohlc(self.settings.pair, interval=self.settings.interval, since=since)
+        data = resp.get("result", {}).get(self.settings.pair)
+        if not data:
+            self.data = pd.DataFrame()
+            return self.data
+        df = pd.DataFrame(data, columns=["time", "open", "high", "low", "close", "vwap", "volume", "count"])
+        df["time"] = pd.to_datetime(df["time"], unit="s")
+        df = df.set_index("time")
         self.data = df
         return df
 

--- a/modules/chatbot/limit_cycle_bot.py
+++ b/modules/chatbot/limit_cycle_bot.py
@@ -15,9 +15,7 @@ import lib.lib as lib
 
 @dataclass
 class CycleSettings:
-    symbol: str = "BTC-EUR"  # Yahoo Finance symbol
     pair: str = "XBTEUR"  # Kraken trading pair
-    use_kraken_price: bool = False  # fetch price from Kraken instead of Yahoo
     refresh_rate: int = 2  # seconds between price checks
     startbuy_threshold: float = 0.4  # % difference between initial buy orders
     initial_portfolio_eur: float = 1000.0  # starting capital
@@ -81,17 +79,15 @@ class LimitCycleBot(BaseChatBot):
     # --- Helpers ---------------------------------------------------------
     def _get_price(self) -> float | None:
         """Return the latest price from the configured source."""
-        if self.settings.use_kraken_price:
-            data = self.fetch_kraken_ticker(self.settings.pair)
-            if not data or data.get("error"):
-                return None
-            result = data.get("result")
-            if not result:
-                return None
-            info = next(iter(result.values()))
-            last = info.get("c", [None])[0]
-            return float(last) if last is not None else None
-        return self.fetch_yahoo_price(self.settings.symbol)
+        data = self.fetch_kraken_ticker(self.settings.pair)
+        if not data or data.get("error"):
+            return None
+        result = data.get("result")
+        if not result:
+            return None
+        info = next(iter(result.values()))
+        last = info.get("c", [None])[0]
+        return float(last) if last is not None else None
 
     def _create_snapshot(self, price: float) -> dict:
         """Return the current state values for change detection."""
@@ -150,11 +146,7 @@ class LimitCycleBot(BaseChatBot):
 
         current_value = self.eur_balance + self.asset_balance * price
         elapsed = int(time.time() - self.start_time)
-        asset_label = (
-            self.settings.pair
-            if self.settings.use_kraken_price
-            else self.settings.symbol
-        )
+        asset_label = self.settings.pair
         lines = [
             f"[LOG {elapsed}s] Portfolio Status:",
             f"Asset:               {asset_label}",
@@ -165,9 +157,7 @@ class LimitCycleBot(BaseChatBot):
             f"Freies Kapital:      {self.eur_balance:.2f} €",
         ]
         if self.asset_balance > 0:
-            asset = self.settings.symbol.split("-")[0]
-            if self.settings.use_kraken_price:
-                asset = self.settings.pair[:3]
+            asset = self.settings.pair[:3]
             lines.append(f"Bestand:            {self.asset_balance:.8f} {asset}")
         if self.last_buy_price:
             lines.append(f"Letzter Kaufkurs:    {self.last_buy_price:.4f} €")

--- a/modules/chatbot/live_trader_bot.py
+++ b/modules/chatbot/live_trader_bot.py
@@ -9,16 +9,16 @@ from dataclasses import dataclass, asdict
 from typing import Dict, Optional
 
 import pandas as pd
-import yfinance as yf
+from lib import kraken_api
 
 
 @dataclass
 class LiveSettings:
     """Configuration for :class:`LiveTraderBot`."""
 
-    symbol: str = "BTC-EUR"  # ticker symbol
+    pair: str = "XBTEUR"  # trading pair
     lookback_days: int = 30  # days of data to analyse
-    interval: str = "1h"  # data granularity
+    interval: int = 60  # data granularity in minutes
     trade_amount: float = 1000.0  # amount used per trade
     profit_target_pct: float = 1.5  # desired profit percentage
     check_interval: int = 30  # seconds between price checks
@@ -77,10 +77,14 @@ class LiveTraderBot:
                 self.settings.telegram_enabled = False
 
     def _fetch_data(self) -> pd.DataFrame:
-        ticker = yf.Ticker(self.settings.symbol)
-        period = f"{self.settings.lookback_days}d"
-        df = ticker.history(period=period, interval=self.settings.interval)
-        return df.dropna()
+        since = int((pd.Timestamp.utcnow() - pd.Timedelta(days=self.settings.lookback_days)).timestamp())
+        resp = kraken_api.ohlc(self.settings.pair, interval=self.settings.interval, since=since)
+        data = resp.get("result", {}).get(self.settings.pair)
+        if not data:
+            return pd.DataFrame()
+        df = pd.DataFrame(data, columns=["time", "open", "high", "low", "close", "vwap", "volume", "count"])
+        df["time"] = pd.to_datetime(df["time"], unit="s")
+        return df.set_index("time")
 
     def _write_state(self, info: Dict) -> None:
         try:
@@ -164,10 +168,7 @@ class LiveTraderBot:
         self._log({"telegram_message": text})
 
     def _interval_seconds(self) -> int:
-        try:
-            return int(pd.Timedelta(self.settings.interval).total_seconds())
-        except ValueError:
-            return 0
+        return int(self.settings.interval * 60)
 
     def _compute_price_slope(self, prices: pd.Series) -> float:
         """Return price change per second over the configured slope window."""
@@ -193,14 +194,14 @@ class LiveTraderBot:
 
     def run(self) -> None:
         print(
-            f"Starting LiveTraderBot for {self.settings.symbol} with trade amount {self.settings.trade_amount}"
+            f"Starting LiveTraderBot for {self.settings.pair} with trade amount {self.settings.trade_amount}"
         )
         while True:
             df = self._fetch_data()
-            price = float(df["Close"].iloc[-1])
-            prev_price = float(df["Close"].iloc[-2]) if len(df) > 1 else price
-            short_ma = float(df["Close"].rolling(window=7).mean().iloc[-1])
-            long_ma = float(df["Close"].rolling(window=25).mean().iloc[-1])
+            price = float(df["close"].iloc[-1])
+            prev_price = float(df["close"].iloc[-2]) if len(df) > 1 else price
+            short_ma = float(df["close"].rolling(window=7).mean().iloc[-1])
+            long_ma = float(df["close"].rolling(window=25).mean().iloc[-1])
 
             window_points = max(
                 2,
@@ -209,7 +210,7 @@ class LiveTraderBot:
                 )
                 + 1,
             )
-            recent_prices = df["Close"].tail(window_points)
+            recent_prices = df["close"].tail(window_points)
             price_slope = self._compute_price_slope(recent_prices)
 
             action = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ prettytable
 PyQt5
 python-telegram-bot==20.7
 urllib3
-yfinance


### PR DESCRIPTION
## Summary
- fetch OHLC data from Kraken API
- remove Yahoo Finance usage from bots and docs
- use rate-limited ticker calls in `BaseChatBot`
- update example configs and docs accordingly
- drop unused yfinance dependency

## Testing
- `python -m compileall -q lib modules`

------
https://chatgpt.com/codex/tasks/task_b_685c77308d0c832a8d26bf3ebb347c61