### PR TITLE
Handle network errors in fetch_kraken_ticker

### DIFF
--- a/modules/chatbot/base.py
+++ b/modules/chatbot/base.py
@@ -1,6 +1,9 @@
 """Base classes and helpers for strategy chatbots."""
 
 import time
+from typing import Any, Dict
+
+from requests import RequestException
 
 from lib import kraken_api
 
@@ -11,13 +14,18 @@ class BaseChatBot:
     _last_call = 0.0
     _rate_limit = 1.0  # seconds between public requests
 
-    def fetch_kraken_ticker(self, pair: str = "XBTUSD") -> dict:
+    def fetch_kraken_ticker(self, pair: str = "XBTUSD") -> Dict[str, Any]:
         """Return ticker info for a currency pair using Kraken public API."""
         wait = self._rate_limit - (time.time() - self._last_call)
         if wait > 0:
             time.sleep(wait)
-        data = kraken_api.ticker(pair)
-        self._last_call = time.time()
+        try:
+            data = kraken_api.ticker(pair)
+        except RequestException:
+            # Network access might be blocked in some environments
+            data = {}
+        finally:
+            self._last_call = time.time()
         return data
 
 


### PR DESCRIPTION
## Summary
- import RequestException and typing helpers
- catch network errors when calling Kraken API

## Testing
- `python -m py_compile modules/chatbot/base.py`
- `python -m py_compile modules/chatbot/limit_cycle_bot.py`


------
https://chatgpt.com/codex/tasks/task_b_685c9173fc74832a816eadecd2b53ccd