### PR TITLE
Add cycle bot backtest

### DIFF
--- a/config/chatbot/cycle_backtest_settings.json.example
+++ b/config/chatbot/cycle_backtest_settings.json.example
@@ -1,0 +1,18 @@
+{
+    "pair": "XBTEUR",
+    "refresh_rate": 0,
+    "startbuy_threshold": 0.4,
+    "initial_portfolio_eur": 1000,
+    "reinvestment_percent": 15,
+    "take_profit_percent": {"start": 0.6, "end": 1.0, "step": 0.2},
+    "buyback_percent": {"start": 0.4, "end": 0.6, "step": 0.1},
+    "safety_offset": {"start": 0.1, "end": 0.2, "step": 0.05},
+    "enable_stop_loss": [false, true],
+    "stop_loss_percent": {"start": 1.0, "end": 3.0, "step": 1.0},
+    "debug": false,
+    "log_interval_terminal": 1,
+    "log_interval_file": 1,
+    "auto_log": true,
+    "data_file": "data/prices.csv",
+    "duration": "1w"
+}

--- a/docs/limit_cycle_bot.md
+++ b/docs/limit_cycle_bot.md
@@ -69,3 +69,22 @@ runner. Copy ``config/chatbot/test_runner_settings.json.example`` to
 Allowed units are ``m`` (minutes), ``h`` (hours), ``d`` (days), ``w`` (weeks),
 ``mo`` (months) and ``y`` (years). Use ``"infinite"`` for an unlimited run.
 Start the tests from the chatbot menu with option ``5``.
+
+## Historical simulation
+
+The ``BacktestLimitCycleBot`` runs the cycle strategy against saved price data and
+tries multiple parameter combinations. Copy
+``config/chatbot/cycle_backtest_settings.json.example`` to
+``config/chatbot/cycle_backtest_settings.json`` and adjust the values. Provide a
+CSV file via the ``data_file`` field containing ``time`` and ``close`` columns.
+Ranges for the tested settings use objects with ``start``, ``end`` and ``step``
+or a list of explicit values.
+
+Start the backtest with:
+
+```bash
+python -m modules.chatbot.cycle_backtest
+```
+
+Logs are written to ``log/test/`` and ``summary.log`` lists all profits along
+with the top five configurations.

--- a/modules/chatbot/chatbot.py
+++ b/modules/chatbot/chatbot.py
@@ -15,6 +15,7 @@ def run() -> None:
     print("4. Run limit cycle bot")
     print("5. Run cycle bot tests")
     print("6. Evaluate cycle bot logs")
+    print("7. Run cycle backtest")
     print("99. Back")
     choice = input("Option: ") or "99"
     if choice == "1":
@@ -61,5 +62,9 @@ def run() -> None:
 
         num = input("Number of results (default 5): ") or "5"
         find_best(int(num))
+    elif choice == "7":
+        from .cycle_backtest import run_backtest
+
+        run_backtest()
 
 

--- a/modules/chatbot/cycle_backtest.py
+++ b/modules/chatbot/cycle_backtest.py
@@ -1,0 +1,147 @@
+import json
+import os
+import itertools
+from typing import Iterable, List, Dict, Any
+
+import pandas as pd
+
+from .limit_cycle_bot import LimitCycleBot, CycleSettings
+
+
+def _parse_duration(text: str) -> float | None:
+    """Return duration in seconds for a string like '10m' or '2h'."""
+    if not text:
+        return None
+    text = text.strip().lower()
+    if text in {"inf", "infinite", "infinity"}:
+        return None
+    value = ""
+    unit = ""
+    for c in text:
+        if c.isdigit():
+            value += c
+        else:
+            unit += c
+    if not value or not unit:
+        return None
+    value = int(value)
+    if unit in {"s", "sec", "secs", "second", "seconds"}:
+        mul = 1
+    elif unit in {"m", "min", "mins", "minute", "minutes"}:
+        mul = 60
+    elif unit in {"h", "hr", "hrs", "hour", "hours"}:
+        mul = 60 * 60
+    elif unit in {"d", "day", "days"}:
+        mul = 60 * 60 * 24
+    elif unit in {"w", "week", "weeks"}:
+        mul = 60 * 60 * 24 * 7
+    elif unit in {"mo", "mon", "month", "months"}:
+        mul = 60 * 60 * 24 * 30
+    elif unit in {"y", "yr", "year", "years"}:
+        mul = 60 * 60 * 24 * 365
+    else:
+        return None
+    return value * mul
+
+
+def _expand(value: Any) -> List[Any]:
+    """Expand scalar or range object to a list of values."""
+    if isinstance(value, dict):
+        start = float(value.get("start", 0))
+        end = float(value.get("end", start))
+        step = float(value.get("step", 1))
+        result: List[Any] = []
+        x = start
+        while x <= end + 1e-9:
+            result.append(round(x, 10))
+            x += step
+        return result
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+class BacktestLimitCycleBot(LimitCycleBot):
+    """LimitCycleBot using predefined price data instead of live quotes."""
+
+    def __init__(self, settings: CycleSettings, prices: Iterable[float]):
+        super().__init__(settings)
+        self._prices = list(prices)
+        self._index = 0
+
+    def _get_price(self) -> float | None:  # type: ignore[override]
+        if self._index >= len(self._prices):
+            return None
+        price = float(self._prices[self._index])
+        self._index += 1
+        return price
+
+
+def _load_prices(path: str, duration: float | None) -> List[float]:
+    df = pd.read_csv(path)
+    if "time" in df.columns:
+        df["time"] = pd.to_datetime(df["time"])
+        if duration is not None:
+            end = df["time"].max()
+            start = end - pd.Timedelta(seconds=duration)
+            df = df[df["time"] >= start]
+    if "close" in df.columns:
+        return df["close"].tolist()
+    return df.iloc[:, -1].tolist()
+
+
+def run_backtest(settings_file: str = "config/chatbot/cycle_backtest_settings.json") -> None:
+    with open(settings_file, "r") as fh:
+        cfg = json.load(fh)
+
+    duration = _parse_duration(str(cfg.get("duration", "")))
+    data_file = cfg.get("data_file")
+    if not data_file:
+        print("No data_file specified in settings")
+        return
+    if not os.path.exists(data_file):
+        print(f"Data file {data_file} not found")
+        return
+    prices = _load_prices(data_file, duration)
+    if not prices:
+        print("No price data loaded")
+        return
+
+    vary_keys = [
+        "take_profit_percent",
+        "buyback_percent",
+        "safety_offset",
+        "enable_stop_loss",
+        "stop_loss_percent",
+    ]
+    base = {k: v for k, v in cfg.items() if k not in vary_keys}
+    ranges: Dict[str, List[Any]] = {k: _expand(cfg.get(k)) for k in vary_keys}
+
+    combos = list(itertools.product(*ranges.values()))
+    os.makedirs(os.path.join("log", "test"), exist_ok=True)
+    results = []
+    for idx, combo in enumerate(combos, 1):
+        params = dict(zip(vary_keys, combo))
+        current = base | params
+        settings = CycleSettings(**{k: v for k, v in current.items() if k in CycleSettings.__annotations__})
+        bot = BacktestLimitCycleBot(settings, prices)
+        log_name = f"cycle_backtest_{idx:04d}.log"
+        bot.run(max_iterations=len(prices), log_dir=os.path.join("log", "test"), log_name=log_name)
+        results.append((bot.total_profit, params, log_name))
+        print(f"Finished test {idx}/{len(combos)} -> Profit {bot.total_profit:.2f} €")
+
+    results.sort(key=lambda x: x[0], reverse=True)
+    summary_path = os.path.join("log", "test", "summary.log")
+    with open(summary_path, "w") as fh:
+        for profit, params, log_name in results:
+            fh.write(f"{log_name}: {profit:.2f} €\n")
+            fh.write(json.dumps(params) + "\n")
+        fh.write("\nTop 5 results:\n")
+        for profit, params, log_name in results[:5]:
+            fh.write(f"{log_name}: {profit:.2f} €\n")
+            fh.write(json.dumps(params) + "\n")
+    print(f"Results written to {summary_path}")
+
+
+if __name__ == "__main__":
+    run_backtest()


### PR DESCRIPTION
## Summary
- add cycle bot backtest module to run historical simulations using CSV data
- add example configuration for backtests
- expose backtest option in chatbot menu
- document how to run the new backtest feature

## Testing
- `python -m py_compile modules/chatbot/chatbot.py modules/chatbot/cycle_backtest.py`

------
https://chatgpt.com/codex/tasks/task_b_685c97c53d94832a9f3b1f2e0e5f64e4