### PR TITLE
Load cycle backtest data from Kraken

### DIFF
--- a/config/chatbot/cycle_backtest_settings.json.example
+++ b/config/chatbot/cycle_backtest_settings.json.example
@@ -13,6 +13,6 @@
     "log_interval_terminal": 1,
     "log_interval_file": 1,
     "auto_log": true,
-    "data_file": "data/prices.csv",
+    "interval": 60,
     "duration": "1w"
 }

--- a/docs/limit_cycle_bot.md
+++ b/docs/limit_cycle_bot.md
@@ -72,13 +72,13 @@ Start the tests from the chatbot menu with option ``5``.
 
 ## Historical simulation
 
-The ``BacktestLimitCycleBot`` runs the cycle strategy against saved price data and
-tries multiple parameter combinations. Copy
+The ``BacktestLimitCycleBot`` runs the cycle strategy against historical prices
+loaded directly from Kraken. Copy
 ``config/chatbot/cycle_backtest_settings.json.example`` to
-``config/chatbot/cycle_backtest_settings.json`` and adjust the values. Provide a
-CSV file via the ``data_file`` field containing ``time`` and ``close`` columns.
-Ranges for the tested settings use objects with ``start``, ``end`` and ``step``
-or a list of explicit values.
+``config/chatbot/cycle_backtest_settings.json`` and adjust the values. The bot
+queries OHLC data for the configured pair and interval, so no CSV file is
+required. Ranges for the tested settings use objects with ``start``, ``end`` and
+``step`` or a list of explicit values.
 
 Start the backtest with:
 

--- a/modules/chatbot/cycle_backtest.py
+++ b/modules/chatbot/cycle_backtest.py
@@ -4,6 +4,9 @@ import itertools
 from typing import Iterable, List, Dict, Any
 
 import pandas as pd
+import requests
+
+from lib import kraken_api
 
 from .limit_cycle_bot import LimitCycleBot, CycleSettings
 
@@ -77,17 +80,23 @@ class BacktestLimitCycleBot(LimitCycleBot):
         return price
 
 
-def _load_prices(path: str, duration: float | None) -> List[float]:
-    df = pd.read_csv(path)
-    if "time" in df.columns:
-        df["time"] = pd.to_datetime(df["time"])
-        if duration is not None:
-            end = df["time"].max()
-            start = end - pd.Timedelta(seconds=duration)
-            df = df[df["time"] >= start]
-    if "close" in df.columns:
-        return df["close"].tolist()
-    return df.iloc[:, -1].tolist()
+def _load_prices(pair: str, interval: int, duration: float | None) -> List[float]:
+    """Return close prices fetched from Kraken's OHLC endpoint."""
+    since = None
+    if duration is not None:
+        since = int((pd.Timestamp.utcnow() - pd.Timedelta(seconds=duration)).timestamp())
+    try:
+        resp = kraken_api.ohlc(pair, interval=interval, since=since)
+    except requests.RequestException:
+        return []
+    data = resp.get("result", {}).get(pair)
+    if not data:
+        return []
+    df = pd.DataFrame(
+        data,
+        columns=["time", "open", "high", "low", "close", "vwap", "volume", "count"],
+    )
+    return df["close"].astype(float).tolist()
 
 
 def run_backtest(settings_file: str = "config/chatbot/cycle_backtest_settings.json") -> None:
@@ -95,14 +104,9 @@ def run_backtest(settings_file: str = "config/chatbot/cycle_backtest_settings.js
         cfg = json.load(fh)
 
     duration = _parse_duration(str(cfg.get("duration", "")))
-    data_file = cfg.get("data_file")
-    if not data_file:
-        print("No data_file specified in settings")
-        return
-    if not os.path.exists(data_file):
-        print(f"Data file {data_file} not found")
-        return
-    prices = _load_prices(data_file, duration)
+    pair = cfg.get("pair", "XBTEUR")
+    interval = int(cfg.get("interval", 60))
+    prices = _load_prices(pair, interval, duration)
     if not prices:
         print("No price data loaded")
         return


### PR DESCRIPTION
## Summary
- fetch historical prices for the cycle backtest via Kraken's OHLC endpoint
- drop CSV requirement from cycle_backtest
- document new behaviour in limit_cycle_bot docs
- adjust cycle_backtest example settings

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m modules.chatbot.cycle_backtest` *(fails: No price data loaded)*

------
https://chatgpt.com/codex/tasks/task_b_685c9bfc4fac832ab8531e264f1d3303