### PR TITLE
Add trading fee setting to limit cycle bot

### DIFF
--- a/config/chatbot/cycle_backtest_settings.json.example
+++ b/config/chatbot/cycle_backtest_settings.json.example
@@ -9,6 +9,7 @@
     "safety_offset": {"start": 0.1, "end": 0.2, "step": 0.05},
     "enable_stop_loss": [false, true],
     "stop_loss_percent": {"start": 1.0, "end": 3.0, "step": 1.0},
+    "est_trading_fee": 0.26,
     "debug": false,
     "log_interval_terminal": 1,
     "log_interval_file": 1,

--- a/config/chatbot/limit_cycle_settings.json.example
+++ b/config/chatbot/limit_cycle_settings.json.example
@@ -9,6 +9,7 @@
     "safety_offset": 0.15,
     "enable_stop_loss": false,
     "stop_loss_percent": 2.0,
+    "est_trading_fee": 0.26,
     "debug": true,
     "log_interval_terminal": 1,
     "log_interval_file": 1,

--- a/docs/limit_cycle_bot.md
+++ b/docs/limit_cycle_bot.md
@@ -20,6 +20,7 @@ Copy `config/chatbot/limit_cycle_settings.json.example` to `config/chatbot/limit
     "safety_offset": 0.15,
     "enable_stop_loss": false,
     "stop_loss_percent": 2.0,
+    "est_trading_fee": 0.26,
     "debug": true,
     "log_interval_terminal": 1,
     "log_interval_file": 1,
@@ -39,6 +40,7 @@ Copy `config/chatbot/limit_cycle_settings.json.example` to `config/chatbot/limit
 - **safety_offset** – Offset applied to limit orders to increase the chance of execution.
 - **enable_stop_loss** – If `true`, the bot places a stop-loss order after each buy.
 - **stop_loss_percent** – Distance below the buy price at which the stop-loss triggers.
+- **est_trading_fee** – Estimated trading fee percentage deducted from each buy and sell.
 - **debug** – If `true`, the bot prints all status information to the console.
 - **log_interval_terminal** – Number of refresh cycles between terminal log outputs.
 - **log_interval_file** – Number of refresh cycles between file log entries.

--- a/modules/chatbot/limit_cycle_bot.py
+++ b/modules/chatbot/limit_cycle_bot.py
@@ -25,6 +25,7 @@ class CycleSettings:
     safety_offset: float = 0.15  # margin on limit orders
     enable_stop_loss: bool = False  # activate stop-loss handling
     stop_loss_percent: float = 2.0  # loss threshold relative to buy price
+    est_trading_fee: float = 0.26  # estimated trading fee percentage
     debug: bool = True  # print debug information
     log_interval_terminal: int = (
         1  # number of refresh cycles between terminal log output
@@ -205,10 +206,11 @@ class LimitCycleBot(BaseChatBot):
         self, sell_price: float, amount: float, stop_loss: bool = False
     ) -> None:
         eur_received = amount * sell_price
-        self.eur_balance += eur_received
+        sell_fee = eur_received * self.settings.est_trading_fee / 100
+        self.eur_balance += eur_received - sell_fee
         self.asset_balance = 0.0
         buy_eur = self.current_buy_amount
-        profit_eur = eur_received - buy_eur
+        profit_eur = eur_received - sell_fee - buy_eur
         profit_pct = profit_eur / buy_eur * 100
         self.total_profit += profit_eur
         self.last_profit = {
@@ -307,10 +309,12 @@ class LimitCycleBot(BaseChatBot):
             buy_price = self.open_buy_low.price
             amount = self.open_buy_low.amount
             cost = buy_price * amount
-            self.eur_balance -= cost
+            buy_fee = cost * self.settings.est_trading_fee / 100
+            self.eur_balance -= cost + buy_fee
             self.asset_balance += amount
             self.last_buy_price = buy_price
             self.high_since_buy = buy_price
+            self.current_buy_amount = cost + buy_fee
             if self.settings.debug:
                 lib.highlight_message(
                     f"BUY executed at {buy_price:.4f} € for {cost:.2f} €"
@@ -333,10 +337,12 @@ class LimitCycleBot(BaseChatBot):
                 buy_price = self.open_buy_high.price
                 amount = self.open_buy_high.amount
                 cost = buy_price * amount
-                self.eur_balance -= cost
+                buy_fee = cost * self.settings.est_trading_fee / 100
+                self.eur_balance -= cost + buy_fee
                 self.asset_balance += amount
                 self.last_buy_price = buy_price
                 self.high_since_buy = buy_price
+                self.current_buy_amount = cost + buy_fee
                 if self.settings.debug:
                     lib.highlight_message(
                         f"BUY executed at {buy_price:.4f} € for {cost:.2f} €"


### PR DESCRIPTION
## Summary
- support an `est_trading_fee` percentage in `CycleSettings`
- deduct buy/sell fees in `LimitCycleBot` profit calculation
- document new option in limit cycle bot docs
- update example configuration files

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_685c9e5eeb58832ab2e9c82695c93e6d