### PR TITLE
Improve cycle backtest data handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ config/chatbot/cycle_backtest_settings.json
 # Ignore generated output and data files
 output/
 data/
+historical_data/
 
 # Misc
 *.log

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Generated data such as CSV exports is stored in the `output/` directory. The
 folder only contains a `readme.md` placeholder by default and will be populated
 once modules are executed.
 
+Historical price downloads used by the cycle backtest are cached in the
+`historical_data/` folder. The files are created automatically on first use so
+multiple backtest runs do not repeatedly query the Kraken API.
+
 ## Telegram Bot
 
 The Telegram bot allows read-only access to your Kraken account. After

--- a/docs/limit_cycle_bot.md
+++ b/docs/limit_cycle_bot.md
@@ -75,12 +75,15 @@ Start the tests from the chatbot menu with option ``5``.
 ## Historical simulation
 
 The ``BacktestLimitCycleBot`` runs the cycle strategy against historical prices
-loaded directly from Kraken. Copy
+loaded from Kraken. Because only a limited amount of data can be fetched per
+request, the backtest repeatedly queries OHLC values using the ``since``
+parameter until the entire period is downloaded. The results are cached in the
+``historical_data/`` directory. On subsequent runs the data is read from the
+cache so no additional API calls are necessary. Copy
 ``config/chatbot/cycle_backtest_settings.json.example`` to
-``config/chatbot/cycle_backtest_settings.json`` and adjust the values. The bot
-queries OHLC data for the configured pair and interval, so no CSV file is
-required. Ranges for the tested settings use objects with ``start``, ``end`` and
-``step`` or a list of explicit values.
+``config/chatbot/cycle_backtest_settings.json`` and adjust the values. Ranges
+for the tested settings use objects with ``start``, ``end`` and ``step`` or a
+list of explicit values.
 
 Start the backtest with:
 

--- a/modules/chatbot/cycle_backtest.py
+++ b/modules/chatbot/cycle_backtest.py
@@ -81,22 +81,69 @@ class BacktestLimitCycleBot(LimitCycleBot):
 
 
 def _load_prices(pair: str, interval: int, duration: float | None) -> List[float]:
-    """Return close prices fetched from Kraken's OHLC endpoint."""
+    """Return close prices fetched from Kraken's OHLC endpoint.
+
+    The OHLC endpoint returns a limited number of data points. When a duration
+    is provided we repeatedly request data using the ``since`` parameter until
+    the full period is covered. The downloaded prices are cached in
+    ``historical_data/`` so subsequent runs do not hit the API again.
+    """
+
+    os.makedirs("historical_data", exist_ok=True)
+    cache_file = os.path.join(
+        "historical_data",
+        f"{pair}_{interval}.csv",
+    )
+
+    if os.path.exists(cache_file):
+        df = pd.read_csv(cache_file)
+        return df["close"].astype(float).tolist()
+
     since = None
     if duration is not None:
-        since = int((pd.Timestamp.utcnow() - pd.Timedelta(seconds=duration)).timestamp())
-    try:
-        resp = kraken_api.ohlc(pair, interval=interval, since=since)
-    except requests.RequestException:
+        since = int(
+            (pd.Timestamp.utcnow() - pd.Timedelta(seconds=duration)).timestamp()
+        )
+
+    all_frames: List[pd.DataFrame] = []
+    last = since
+    while True:
+        try:
+            resp = kraken_api.ohlc(pair, interval=interval, since=last)
+        except requests.RequestException:
+            break
+
+        result = resp.get("result", {})
+        data = result.get(pair)
+        if not data:
+            break
+
+        df = pd.DataFrame(
+            data,
+            columns=[
+                "time",
+                "open",
+                "high",
+                "low",
+                "close",
+                "vwap",
+                "volume",
+                "count",
+            ],
+        )
+        all_frames.append(df)
+
+        new_last = result.get("last")
+        if new_last is None or new_last == last:
+            break
+        last = new_last
+
+    if not all_frames:
         return []
-    data = resp.get("result", {}).get(pair)
-    if not data:
-        return []
-    df = pd.DataFrame(
-        data,
-        columns=["time", "open", "high", "low", "close", "vwap", "volume", "count"],
-    )
-    return df["close"].astype(float).tolist()
+
+    df_all = pd.concat(all_frames, ignore_index=True)
+    df_all.to_csv(cache_file, index=False)
+    return df_all["close"].astype(float).tolist()
 
 
 def run_backtest(settings_file: str = "config/chatbot/cycle_backtest_settings.json") -> None:


### PR DESCRIPTION
## Summary
- cache OHLC data for cycle backtests in `historical_data/`
- fetch multiple batches using `since` to cover the full period
- document price caching in README and limit-cycle bot guide
- ignore `historical_data` in git

## Testing
- `pip install -r requirements.txt`
- `python -m modules.chatbot.cycle_backtest` *(fails: No price data loaded)*

------
https://chatgpt.com/codex/tasks/task_b_685caf02fd20832a98cf08ee6743c9dd