### PR TITLE
Fix OHLC data retrieval

### DIFF
--- a/modules/chatbot/cycle_backtest.py
+++ b/modules/chatbot/cycle_backtest.py
@@ -115,6 +115,12 @@ def _load_prices(pair: str, interval: int, duration: float | None) -> List[float
 
         result = resp.get("result", {})
         data = result.get(pair)
+        if data is None:
+            # some pairs are returned with asset class prefixes (e.g. XXBTZEUR)
+            for key, val in result.items():
+                if key != "last":
+                    data = val
+                    break
         if not data:
             break
 


### PR DESCRIPTION
## Summary
- handle alias return keys from Kraken OHLC endpoint when fetching historical data

## Testing
- `python -m modules.chatbot.cycle_backtest` *(fails: No price data due to network block)*
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_b_685cb166187c832a98175f91961e86e6