### PR TITLE
Fix OHLC cache refresh

### DIFF
--- a/docs/limit_cycle_bot.md
+++ b/docs/limit_cycle_bot.md
@@ -79,7 +79,8 @@ loaded from Kraken. Because only a limited amount of data can be fetched per
 request, the backtest repeatedly queries OHLC values using the ``since``
 parameter until the entire period is downloaded. The results are cached in the
 ``historical_data/`` directory. On subsequent runs the data is read from the
-cache so no additional API calls are necessary. Copy
+cache so no additional API calls are necessary. If the configured duration
+exceeds the cached range the data is downloaded again automatically. Copy
 ``config/chatbot/cycle_backtest_settings.json.example`` to
 ``config/chatbot/cycle_backtest_settings.json`` and adjust the values. Ranges
 for the tested settings use objects with ``start``, ``end`` and ``step`` or a

--- a/modules/chatbot/cycle_backtest.py
+++ b/modules/chatbot/cycle_backtest.py
@@ -95,15 +95,18 @@ def _load_prices(pair: str, interval: int, duration: float | None) -> List[float
         f"{pair}_{interval}.csv",
     )
 
-    if os.path.exists(cache_file):
-        df = pd.read_csv(cache_file)
-        return df["close"].astype(float).tolist()
-
     since = None
     if duration is not None:
         since = int(
             (pd.Timestamp.utcnow() - pd.Timedelta(seconds=duration)).timestamp()
         )
+
+    if os.path.exists(cache_file):
+        df = pd.read_csv(cache_file)
+        earliest = int(df["time"].iloc[0])
+        if since is None or earliest <= since:
+            return df["close"].astype(float).tolist()
+        # cached data does not cover requested period -> refresh
 
     all_frames: List[pd.DataFrame] = []
     last = since


### PR DESCRIPTION
## Summary
- refresh historical OHLC cache when requested period goes further back
- document automatic refresh in limit cycle bot docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_b_685cb5629e10832a867d6d9142565ab7