### PR TITLE
Fix JSON loader not to overwrite files

### DIFF
--- a/lib/lib.py
+++ b/lib/lib.py
@@ -5,7 +5,6 @@ import json
 import pandas as pd
 import os
 import sys
-from PyQt5.QtWidgets import QApplication, QFileDialog
 ### self created
 lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, lib_path)
@@ -252,12 +251,11 @@ def load_json_file(filename, path_to_folder):
         with open(filename, "r") as f:
             data = json.load(f)
     else:
-        # Die Datei ist nicht vorhanden, also wird sie erstellt und mit einem leeren Dictionary initialisiert
+        # Die Datei ist nicht vorhanden, also wird sie erstellt
         data = {}
+        with open(filename, "w") as f:
+            json.dump(data, f, indent=4)
 
-    # Schreiben Sie das aktualisierte Dictionary in die Datei
-    with open(filename, "w") as f:
-        json.dump(data, f, indent=4)
             
     return data, filename
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 requests
 pandas
 prettytable
-PyQt5
 python-telegram-bot==20.7
 urllib3


### PR DESCRIPTION
## Summary
- avoid overwriting credential files when loading JSON

## Testing
- `python3 -m py_compile lib/lib.py`
- `python3 -m py_compile modules/api_editor/api_list.py modules/withdraw_adress/withdraw_adresses.py modules/kraken_request/kraken_request.py modules/telegram_bot/telegram_bot.py`


------
https://chatgpt.com/codex/tasks/task_b_68613be7b97c832aadf5db903b508b41